### PR TITLE
add automatic tiling of new windows

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
@@ -22,6 +22,11 @@
             <summary>Enable snap assist</summary>
             <description>Move the window on top of the screen to snap assist it.</description>
         </key>
+        <key name="tile-new-windows" type="b">
+            <default>false</default>
+            <summary>Tile New Windows</summary>
+            <description>Automatically move new windows into empty tiles.</description>
+        </key>        
         <key name="show-indicator" type="b">
             <default>true</default>
             <summary>Shows indicator</summary>

--- a/src/components/tilingsystem/resizeManager.ts
+++ b/src/components/tilingsystem/resizeManager.ts
@@ -21,7 +21,7 @@ export class ResizingManager {
 
     /** From Gnome Shell: https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/altTab.js#L53
      */
-    private _getWindows(): Meta.Window[] {
+    public getWindows(): Meta.Window[] {
         const workspace = global.workspaceManager.get_active_workspace();
         // We ignore skip-taskbar windows in switchers, but if they are attached
         // to their parent, their position in the MRU list may be more appropriate
@@ -71,7 +71,7 @@ export class ResizingManager {
         }
         if (!verticalSide[0] && !horizontalSide[0]) return;
         
-        const otherTiledWindows = this._getWindows().filter(otherWindow => 
+        const otherTiledWindows = this.getWindows().filter(otherWindow => 
             otherWindow && (otherWindow as ExtendedWindow).isTiled && otherWindow !== window && !otherWindow.minimized);
         if (otherTiledWindows.length === 0) return;
         

--- a/src/components/tilingsystem/tilingLayout.ts
+++ b/src/components/tilingsystem/tilingLayout.ts
@@ -74,6 +74,10 @@ export default class TilingLayout extends LayoutWidget<DynamicTilePreview> {
     public get showing(): boolean {
         return this._showing;
     }
+    
+    public get layout(): Layout {
+        return this._layout
+    }
 
     public openBelow(window: Meta.Window) {
         if (this._showing) return;

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -92,6 +92,13 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
         );
         behaviourGroup.add(snapAssistRow);
 
+        const tileNewWindowsRow = this._buildSwitchRow(
+            Settings.SETTING_TILE_NEW_WINDOWS,
+            "Tile New Windows",
+            "Automatically move new windows into empty tiles."
+        );
+        behaviourGroup.add(tileNewWindowsRow);        
+
         const enableTilingSystemRow = this._buildSwitchRow(
             Settings.SETTING_TILING_SYSTEM,
             "Enable Tiling System",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -20,6 +20,7 @@ export default class Settings {
     static SETTING_SELECTED_LAYOUTS = 'selected-layouts';
     static SETTING_RESTORE_WINDOW_ORIGINAL_SIZE = 'restore-window-original-size';
     static SETTING_RESIZE_COMPLEMENTING_WINDOWS = 'resize-complementing-windows';
+    static SETTING_TILE_NEW_WINDOWS = 'tile-new-windows';
 
     static SETTING_MOVE_WINDOW_RIGHT = 'move-window-right';
     static SETTING_MOVE_WINDOW_LEFT = 'move-window-left';
@@ -55,6 +56,10 @@ export default class Settings {
 
     static get_snap_assist_enabled() : boolean {
         return this._settings?.get_boolean(this.SETTING_SNAP_ASSIST) || false;
+    }
+
+    static get_tile_new_windows_enabled() : boolean {
+        return this._settings?.get_boolean(this.SETTING_TILE_NEW_WINDOWS) || false
     }
 
     static get_show_indicator() : boolean {


### PR DESCRIPTION
I've been trying this out for a few days and really liking it. I've used other tiling extensions where the windows are tiled automatically on creation and thought I'd have a go at adding something similar here. I've tied to it a setting that's off by default.

Could still use some work (the movement is pretty violent—I've yet to figure out how to position them before they render) but I thought I'd share. 

https://github.com/domferr/tilingshell/assets/113969694/f131db91-797e-4695-ba90-a73f81e0ff9e

