### PR TITLE
Clamp pointer position to work-area before edge-tiling

### DIFF
--- a/src/components/tilingsystem/edgeTilingManager.ts
+++ b/src/components/tilingsystem/edgeTilingManager.ts
@@ -1,4 +1,4 @@
-import { buildRectangle, isPointInsideRect } from '@utils/ui';
+import { buildRectangle, isPointInsideRect, clampPointInsideRect } from '@utils/ui';
 import Mtk from 'gi://Mtk';
 import Settings from '@settings/settings';
 
@@ -81,12 +81,14 @@ export default class EdgeTilingManager {
         this._rightCenter.width = this._topRight.width;
     }
 
-    public canActivateEdgeTiling(x: number, y: number) {
+    public canActivateEdgeTiling(
+        pointerPos: { x: number; y: number }
+    ): boolean {
         return (
-            x <= this._workArea.x + EDGE_TILING_OFFSET ||
-            y <= this._workArea.y + TOP_EDGE_TILING_OFFSET ||
-            x >= this._workArea.x + this._workArea.width - EDGE_TILING_OFFSET ||
-            y >= this._workArea.y + this._workArea.height - EDGE_TILING_OFFSET
+            pointer.x <= this._workArea.x + EDGE_TILING_OFFSET ||
+            pointer.y <= this._workArea.y + TOP_EDGE_TILING_OFFSET ||
+            pointer.x >= this._workArea.x + this._workArea.width - EDGE_TILING_OFFSET ||
+            pointer.y >= this._workArea.y + this._workArea.height - EDGE_TILING_OFFSET
         );
     }
 
@@ -95,9 +97,9 @@ export default class EdgeTilingManager {
     }
 
     public startEdgeTiling(
-        x: number,
-        y: number,
+        pointerPos: { x: number; y: number }
     ): { changed: boolean; rect: Mtk.Rectangle } {
+        const { x, y } = clampPointInsideRect(pointerPos, this._workArea)
         const previewRect = buildRectangle();
 
         if (

--- a/src/components/tilingsystem/edgeTilingManager.ts
+++ b/src/components/tilingsystem/edgeTilingManager.ts
@@ -85,10 +85,10 @@ export default class EdgeTilingManager {
         pointerPos: { x: number; y: number }
     ): boolean {
         return (
-            pointer.x <= this._workArea.x + EDGE_TILING_OFFSET ||
-            pointer.y <= this._workArea.y + TOP_EDGE_TILING_OFFSET ||
-            pointer.x >= this._workArea.x + this._workArea.width - EDGE_TILING_OFFSET ||
-            pointer.y >= this._workArea.y + this._workArea.height - EDGE_TILING_OFFSET
+            pointerPos.x <= this._workArea.x + EDGE_TILING_OFFSET ||
+            pointerPos.y <= this._workArea.y + TOP_EDGE_TILING_OFFSET ||
+            pointerPos.x >= this._workArea.x + this._workArea.width - EDGE_TILING_OFFSET ||
+            pointerPos.y >= this._workArea.y + this._workArea.height - EDGE_TILING_OFFSET
         );
     }
 

--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -452,10 +452,10 @@ export class TilingManager {
             if (
                 Settings.get_active_screen_edges() &&
                 !this._isSnapAssisting &&
-                this._edgeTilingManager.canActivateEdgeTiling(x, y)
+                this._edgeTilingManager.canActivateEdgeTiling(currPointerPos)
             ) {
                 const { changed, rect } =
-                    this._edgeTilingManager.startEdgeTiling(x, y);
+                    this._edgeTilingManager.startEdgeTiling(currPointerPos);
                 if (changed) this._showEdgeTiling(window, rect, x, y);
                 this._snapAssist.close(true);
             } else {

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -11,7 +11,7 @@ export const getMonitors = (): Monitor[] => Main.layoutManager.monitors;
 export const isPointInsideRect = (
     point: { x: number; y: number },
     rect: Mtk.Rectangle,
-) => {
+): boolean => {
     return (
         point.x >= rect.x &&
         point.x <= rect.x + rect.width &&
@@ -19,6 +19,17 @@ export const isPointInsideRect = (
         point.y <= rect.y + rect.height
     );
 };
+
+export const clampPointInsideRect = (
+    point: { x: number; y: number },
+    rect: Mtk.Rectangle,
+): { x: number; y: number } => {
+    const clamp = (n, min, max) => Math.min(Math.max(n, min), max)
+    return {
+        x: clamp(point.x, rect.x, rect.x + rect.width),
+        y: clamp(point.y, rect.y, rect.y + rect.height),
+    }
+}
 
 export const positionRelativeTo = (
     actor: Clutter.Actor,


### PR DESCRIPTION
Fixes #108 by clamping the pointer position to the `EdgeTilingManager`'s `_workArea` so that edge tiling also works when dragging the window on panels.

See #108 for more information!