### PR TITLE
#81 - Obtain monitor indicies by xrandr to distinguish multiple monitors

### DIFF
--- a/resources/monitorDescription.js
+++ b/resources/monitorDescription.js
@@ -2,14 +2,61 @@
 
 import Gtk from "gi://Gtk";
 import Gdk from "gi://Gdk";
+import GLib from "gi://GLib";
 //const { Gtk, Gdk } = imports.gi;
 
+/**
+* Get the number of monitors connected and their connection type and system index
+* @returns {[number, Object]} The number of monitors connected
+**/
+const getNumberIdentifiers = () => {
+
+    let [success, stdout, stderr, exitCode] = GLib.spawn_command_line_sync('xrandr --listactivemonitors');
+    //Expected output:
+    // Monitors: 2
+    //  0: +*eDP-1 2560/300x1600/190+816+2160  eDP-1
+    //  1: +DP-8 3840/630x2160/360+0+0  DP-8
+
+    if (success) {
+        const output = new TextDecoder().decode(stdout);
+
+        const reMonitorNum = new RegExp(/Monitors:\s(?<num>\d+)/, "gm");
+        const matchMonitorN = reMonitorNum.exec(output);
+
+        const reConnDetails = new RegExp(/(?<idx>\d+):.*\s(?<conn>\w+-\d+)$/, 'gm');
+        const matchConnDetails = output.matchAll(reConnDetails);
+
+        return [parseInt(matchMonitorN.groups['num'], 10), Array.from(matchConnDetails).reduce((prev, currMatch) => {
+            const key = currMatch.groups['conn'];
+            const value = currMatch.groups['idx'];
+            prev[key] = parseInt(value, 10);
+            return prev;
+        }, {})]
+    } else {
+        console.error(`Error #${exitCode} in xrandr command.`);
+        console.error(new TextDecoder.decode(stderr));
+        return [0, {}]
+    }
+}
+
+
+
 Gtk.init();
-const monitors = Gdk.Display.get_default().get_monitors();
+const display = Gdk.Display.get_default();
+const monitors = display.get_monitors();
+
+const randrDetails = getNumberIdentifiers();
+const numberOfMonitors = monitors.get_n_items();
 const details = [];
-for (const m of monitors) {
+for (let idx = 0; idx < numberOfMonitors; idx++) {
+    const m = monitors.get_item(idx);
     const { x, y, width, height } = m.get_geometry();
-    details.push({ name: m.get_description(), x, y, width, height });
+
+    const connector = m.get_connector();
+    console.debug('connector:', connector, 'randrDetails:', JSON.stringify(randrDetails[1]));
+    const index = numberOfMonitors === randrDetails[0] ? randrDetails[1][connector] : null;
+
+    details.push({ name: m.get_description(), x, y, width, height, index });
 }
 
 print(JSON.stringify(details));

--- a/src/indicator/defaultMenu.ts
+++ b/src/indicator/defaultMenu.ts
@@ -114,6 +114,7 @@ class LayoutsRow extends St.BoxLayout {
             y: number;
             height: number;
             width: number;
+            index: number;
         }[],
     ) {
         if (!showMonitorName) this._label.hide();
@@ -124,7 +125,13 @@ class LayoutsRow extends St.BoxLayout {
         );
         if (!details) return;
 
-        this._label.set_text(details.name);
+        if (details.name) {
+            this._label.set_text(
+                `${details?.index !== null ? details.index + 1 : this._monitor.index} - ${details.name}`,
+            );
+        } else {
+            this._label.set_text(`Monitor ${details.index + 1}`);
+        }
     }
 }
 


### PR DESCRIPTION
This is best effort to distinguish multiple monitors. Implementation tries to mimic global settings indexing of monitors using xrandr command in `resources/monitorDescription.js`. 

I observed strange behavior when label is set to fallback value `Monitor {number}`. I don't have any clue how to debug that. 

![Screenshot from 2024-07-31 14-04-51](https://github.com/user-attachments/assets/6cf8c1ce-a1a5-4232-b607-48a8a4fb15c2)

Log output:
```console
Jul 31 14:15:25 fedora-laptop gnome-shell[2636]: [tilingshell] [extension] building a tiling manager for each monitor
Jul 31 14:15:25 fedora-laptop gnome-shell[2636]: [tilingshell] [TilingManager 0] Work area for monitor 0: 0 0 3840x2160
Jul 31 14:15:25 fedora-laptop gnome-shell[2636]: [tilingshell] [TilingManager 1] Work area for monitor 1: 816 2192 2560x1568
```

This usually occurs after turning on laptop already connected to  docking stations. Dirty fix is to lock the laptop and unlocking it again. 