### PR TITLE
Remove fuzzy marker from some italian translations

### DIFF
--- a/translations/it.po
+++ b/translations/it.po
@@ -432,32 +432,26 @@ msgid "Import, export and reset"
 msgstr "Importa, esporta e resetta"
 
 #: dist/prefs.js:1176
-#, fuzzy
 msgid "Import, export and reset the settings of Tiling Shell"
 msgstr "Importa, esporta e resetta le impostazioni di Tiling Shell"
 
 #: dist/prefs.js:1181 dist/prefs.js:1182
-#, fuzzy
 msgid "Export settings"
 msgstr "Esporta le impostazioni"
 
 #: dist/prefs.js:1183
-#, fuzzy
 msgid "Export settings to a file"
 msgstr "Esporta le impostazioni in un file"
 
 #: dist/prefs.js:1186
-#, fuzzy
 msgid "Export settings to a text file"
 msgstr "Esporta le impostazioni in un file di testo"
 
 #: dist/prefs.js:1238 dist/prefs.js:1239
-#, fuzzy
 msgid "Import settings"
 msgstr "Importa le impostazioni"
 
 #: dist/prefs.js:1240
-#, fuzzy
 msgid "Import settings from a file"
 msgstr "Importa le impostazioni da un file"
 


### PR DESCRIPTION
The strings related to settings import/export were still marked as fuzzy in `it.po`.

This probably causes those translations to not show up in the UI:

![image](https://github.com/user-attachments/assets/7629c58a-4c9e-428f-bfff-066affddd4e4)

NOTE: I made this edit directly in GitHub without actually building the extension and verifying this works. Please disregard the PR if this is not the case.