### PR TITLE
feat: add focus next/prev window

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
@@ -67,6 +67,11 @@
             <summary>Restore window size</summary>
             <description>Restore the windows to their original size when untiled.</description>
         </key>
+        <key name="enable-wraparound-focus" type="b">
+            <default>false</default>
+            <summary>Enable next/previous window focus to wrap around</summary>
+            <description>When focusing next or previous window, wrap around at the window edge</description>
+        </key>
         <key name="resize-complementing-windows" type="b">
             <default>true</default>
             <summary>Enable auto-resize of the complementing tiled windows</summary>
@@ -213,6 +218,14 @@
 		<key type="as" name="focus-window-down">
 			<default><![CDATA[['']]]></default>
 			<summary>Focus the window below the current focused window</summary>
+		</key>
+		<key type="as" name="focus-window-next">
+			<default><![CDATA[['']]]></default>
+			<summary>Focus the window next to the current focused window</summary>
+		</key>
+		<key type="as" name="focus-window-prev">
+			<default><![CDATA[['']]]></default>
+			<summary>Focus the window prior to the current focused window</summary>
 		</key>
     </schema>
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -492,7 +492,27 @@ export default class TilingShellExtension extends Extension {
             x: focusWindowRect.x + focusWindowRect.width / 2,
             y: focusWindowRect.y + focusWindowRect.height / 2,
         };
-        getWindows(focus_window.get_workspace())
+
+        const windowList = getWindows(focus_window.get_workspace());
+        const focusedIdx = windowList.findIndex((win) => win === focus_window);
+
+        switch (direction) {
+            case KeyBindingsDirection.PREV:
+                if (focusedIdx == 0 && Settings.WRAPAROUND_FOCUS) {
+                    windowList[windowList.length - 1].activate(global.get_current_time());
+                } else {
+                    windowList[focusedIdx - 1].activate(global.get_current_time());
+                }
+                return;
+            case KeyBindingsDirection.NEXT:
+                const nextIdx = (focusedIdx + 1) % windowList.length;
+                if (nextIdx > 0 || Settings.WRAPAROUND_FOCUS) {
+                    windowList[nextIdx].activate(global.get_current_time());
+                }
+                return;
+        }
+
+        windowList
             .filter((win) => {
                 if (win === focus_window || win.minimized) return false;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import Indicator from './indicator/indicator';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 import { ExtensionMetadata } from 'resource:///org/gnome/shell/extensions/extension.js';
 import DBus from './dbus';
-import KeyBindings, { KeyBindingsDirection } from './keybindings';
+import KeyBindings, { KeyBindingsDirection, FocusSwitchDirection } from './keybindings';
 import SettingsOverride from '@settings/settingsOverride';
 import { ResizingManager } from '@components/tilingsystem/resizeManager';
 import OverriddenWindowMenu from '@components/window_menu/overriddenWindowMenu';
@@ -239,7 +239,7 @@ export default class TilingShellExtension extends Extension {
                 (
                     kb: KeyBindings,
                     dp: Meta.Display,
-                    dir: KeyBindingsDirection,
+                    dir: KeyBindingsDirection | FocusSwitchDirection,
                 ) => {
                     this._onKeyboardFocusWin(dp, dir);
                 },
@@ -471,7 +471,7 @@ export default class TilingShellExtension extends Extension {
 
     private _onKeyboardFocusWin(
         display: Meta.Display,
-        direction: KeyBindingsDirection,
+        direction: KeyBindingsDirection | FocusSwitchDirection,
     ) {
         const focus_window = display.get_focus_window();
         const focusParent = (focus_window.get_transient_for() || focus_window);
@@ -501,14 +501,14 @@ export default class TilingShellExtension extends Extension {
         });
 
         switch (direction) {
-            case KeyBindingsDirection.PREV:
+            case FocusSwitchDirection.PREV:
                 if (focusedIdx == 0 && Settings.WRAPAROUND_FOCUS) {
                     windowList[windowList.length - 1].activate(global.get_current_time());
                 } else {
                     windowList[focusedIdx - 1].activate(global.get_current_time());
                 }
                 return;
-            case KeyBindingsDirection.NEXT:
+            case FocusSwitchDirection.NEXT:
                 const nextIdx = (focusedIdx + 1) % windowList.length;
                 if (nextIdx > 0 || Settings.WRAPAROUND_FOCUS) {
                     windowList[nextIdx].activate(global.get_current_time());

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -14,8 +14,18 @@ export enum KeyBindingsDirection {
     DOWN,
     LEFT,
     RIGHT,
-    PREV,
-    NEXT,
+}
+
+const numKeyBindingDirections =
+    Object.keys(KeyBindingsDirection).
+    filter(key => isNaN(Number(key))).
+    length;
+
+// FocusSwitchDirection values must be exclusive of KeyBindingsDirection
+// because either type could be an argument to Extension._onKeyboardFocusWin
+export enum FocusSwitchDirection {
+    NEXT = (numKeyBindingDirections + 1),
+    PREV = (numKeyBindingDirections + 2),
 }
 
 @registerGObjectClass
@@ -39,7 +49,7 @@ export default class KeyBindings extends GObject.Object {
                 param_types: [Meta.Display.$gtype], // Meta.Display
             },
             'focus-window': {
-                param_types: [Meta.Display.$gtype, GObject.TYPE_INT], // Meta.Display, KeyBindingsDirection
+                param_types: [Meta.Display.$gtype, GObject.TYPE_INT], // Meta.Display, KeyBindingsDirection | FocusSwitchDirection
             },
         },
     };
@@ -186,7 +196,7 @@ export default class KeyBindings extends GObject.Object {
             Meta.KeyBindingFlags.NONE,
             Shell.ActionMode.NORMAL,
             (display: Meta.Display) => {
-                this.emit('focus-window', display, KeyBindingsDirection.NEXT);
+                this.emit('focus-window', display, FocusSwitchDirection.NEXT);
             },
         );
 
@@ -196,7 +206,7 @@ export default class KeyBindings extends GObject.Object {
             Meta.KeyBindingFlags.NONE,
             Shell.ActionMode.NORMAL,
             (display: Meta.Display) => {
-                this.emit('focus-window', display, KeyBindingsDirection.PREV);
+                this.emit('focus-window', display, FocusSwitchDirection.PREV);
             },
         );
     }

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -14,6 +14,8 @@ export enum KeyBindingsDirection {
     DOWN,
     LEFT,
     RIGHT,
+    PREV,
+    NEXT,
 }
 
 @registerGObjectClass
@@ -175,6 +177,26 @@ export default class KeyBindings extends GObject.Object {
             Shell.ActionMode.NORMAL,
             (display: Meta.Display) => {
                 this.emit('focus-window', display, KeyBindingsDirection.DOWN);
+            },
+        );
+
+        Main.wm.addKeybinding(
+            Settings.SETTING_FOCUS_WINDOW_NEXT,
+            extensionSettings,
+            Meta.KeyBindingFlags.NONE,
+            Shell.ActionMode.NORMAL,
+            (display: Meta.Display) => {
+                this.emit('focus-window', display, KeyBindingsDirection.NEXT);
+            },
+        );
+
+        Main.wm.addKeybinding(
+            Settings.SETTING_FOCUS_WINDOW_PREV,
+            extensionSettings,
+            Meta.KeyBindingFlags.NONE,
+            Shell.ActionMode.NORMAL,
+            (display: Meta.Display) => {
+                this.emit('focus-window', display, KeyBindingsDirection.PREV);
             },
         );
     }

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -288,6 +288,12 @@ export default class KeyBindings extends GObject.Object {
         Main.wm.removeKeybinding(Settings.SETTING_SPAN_WINDOW_ALL_TILES);
         Main.wm.removeKeybinding(Settings.SETTING_UNTILE_WINDOW);
         Main.wm.removeKeybinding(Settings.SETTING_MOVE_WINDOW_CENTER);
+        Main.wm.removeKeybinding(Settings.SETTING_FOCUS_WINDOW_UP);
+        Main.wm.removeKeybinding(Settings.SETTING_FOCUS_WINDOW_DOWN);
+        Main.wm.removeKeybinding(Settings.SETTING_FOCUS_WINDOW_LEFT);
+        Main.wm.removeKeybinding(Settings.SETTING_FOCUS_WINDOW_RIGHT);
+        Main.wm.removeKeybinding(Settings.SETTING_FOCUS_WINDOW_NEXT);
+        Main.wm.removeKeybinding(Settings.SETTING_FOCUS_WINDOW_PREV);
     }
 
     private _restoreNatives() {

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -242,6 +242,13 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
         );
         behaviourGroup.add(restoreToOriginalSizeRow);
 
+        const wrapAroundRow = this._buildSwitchRow(
+            Settings.KEY_WRAPAROUND_FOCUS,
+            _('Enable next/previous window focus to wrap around'),
+            _('When focusing next or previous window, wrap around at the window edge'),
+        );
+        behaviourGroup.add(wrapAroundRow);
+
         const overrideWindowMenuRow = this._buildSwitchRow(
             Settings.KEY_OVERRIDE_WINDOW_MENU,
             _('Add snap assistant and auto-tile buttons to window menu'),
@@ -585,6 +592,20 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
                 Settings.SETTING_FOCUS_WINDOW_DOWN,
                 _('Focus window below'),
                 _('Focus the window below the current focused window'),
+                false,
+                false,
+            ],
+            [
+                Settings.SETTING_FOCUS_WINDOW_NEXT,
+                _('Focus next window'),
+                _('Focus the window next to the current focused window'),
+                false,
+                false,
+            ],
+            [
+                Settings.SETTING_FOCUS_WINDOW_PREV,
+                _('Focus previous window'),
+                _('Focus the window prior to the current focused window'),
                 false,
                 false,
             ],

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -89,6 +89,7 @@ export default class Settings {
         'span-multiple-tiles-activation-key';
     static KEY_SPAN_MULTIPLE_TILES = 'enable-span-multiple-tiles';
     static KEY_RESTORE_WINDOW_ORIGINAL_SIZE = 'restore-window-original-size';
+    static KEY_WRAPAROUND_FOCUS = 'enable-wraparound-focus';
     static KEY_RESIZE_COMPLEMENTING_WINDOWS = 'resize-complementing-windows';
     static KEY_ENABLE_BLUR_SNAP_ASSISTANT = 'enable-blur-snap-assistant';
     static KEY_ENABLE_BLUR_SELECTED_TILEPREVIEW =
@@ -126,6 +127,8 @@ export default class Settings {
     static SETTING_FOCUS_WINDOW_LEFT = 'focus-window-left';
     static SETTING_FOCUS_WINDOW_UP = 'focus-window-up';
     static SETTING_FOCUS_WINDOW_DOWN = 'focus-window-down';
+    static SETTING_FOCUS_WINDOW_NEXT = 'focus-window-next';
+    static SETTING_FOCUS_WINDOW_PREV = 'focus-window-prev';
 
     static initialize(settings: Gio.Settings) {
         if (this._is_initialized) return;
@@ -258,6 +261,14 @@ export default class Settings {
 
     static set RESTORE_WINDOW_ORIGINAL_SIZE(val: boolean) {
         set_boolean(Settings.KEY_RESTORE_WINDOW_ORIGINAL_SIZE, val);
+    }
+
+    static get WRAPAROUND_FOCUS(): boolean {
+        return get_boolean(Settings.KEY_WRAPAROUND_FOCUS);
+    }
+
+    static set WRAPAROUND_FOCUS(val: boolean) {
+        set_boolean(Settings.KEY_WRAPAROUND_FOCUS, val);
     }
 
     static get RESIZE_COMPLEMENTING_WINDOWS(): boolean {


### PR DESCRIPTION
This adds two new focus-switching actions: focus next window, and focus previous window, where previous and next windows are determined by the window manager and limited to the current workspace. It also adds an option to wrap around to the beginning of the window list when the extent is reached, e.g. when you're at the last window, focus next will wrap around and focus the first window.

This also fixes a bug where the focus keybindings are not unbound when the extension is disabled, e.g. when the screen is locked, so the attempt to rebind them fails with a message from GNOME Shell that duplicate bindings are being set.