### PR TITLE
fix(prefs): Unexpected closing of the file chooser

### DIFF
--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1167,9 +1167,12 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
             title,
             action,
             select_multiple: false,
-            transientFor: window,
+            modal: true,
             accept_label: accept,
             cancel_label: cancel,
+        });
+        window.connect('map', () => {
+            fc.set_transient_for(window);
         });
         const [major] = Config.PACKAGE_VERSION.split('.').map((s: string) =>
             Number(s),


### PR DESCRIPTION
In GNOME Shell 44, see https://github.com/domferr/tilingshell/pull/245#issuecomment-2593570800.