### PR TITLE
Fix #290: crash hovering over resize handles in Gnome 48

### DIFF
--- a/src/components/editor/slider.ts
+++ b/src/components/editor/slider.ts
@@ -89,10 +89,14 @@ export default class Slider extends St.Button {
     }
 
     private get preferredCursor(): Meta.Cursor {
+        // These constants were renamed in Gnome 48 from NORTH/WEST_* to N/W_*
+        const horizCursor = Meta.Cursor.WEST_RESIZE ?? Meta.Cursor.W_RESIZE;
+        const vertCursor = Meta.Cursor.NORTH_RESIZE ?? Meta.Cursor.N_RESIZE;
+
         return this.hover || this._dragging
             ? this._horizontalDir
-                ? Meta.Cursor.WEST_RESIZE
-                : Meta.Cursor.NORTH_RESIZE
+                ? horizCursor
+                : vertCursor
             : Meta.Cursor.DEFAULT;
     }
 


### PR DESCRIPTION
The cursor constants changed names in Gnome 48, from NORTH/WEST_* to N/W_*. update the preferredCursor() function to handle both pre-Gnome 48 and Gnome 48 cases.

Fixes #290 