### PR TITLE
Allow choosing snap assistant position between TOP and BOTTOM

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
@@ -24,8 +24,13 @@
         </key>
         <key name="enable-snap-assist" type="b">
             <default>true</default>
-            <summary>Enable snap assist</summary>
+            <summary>Enable snap assistant</summary>
             <description>Move the window on top of the screen to snap assist it.</description>
+        </key>
+        <key name="snap-assistant-position" type="i">
+            <default>0</default>
+            <summary>Position of snap assistant</summary>
+            <description>Position of snap assistant, 0 is TOP, 1 is BOTTOM.</description>
         </key>
         <key name="show-indicator" type="b">
             <default>true</default>

--- a/src/components/tilingsystem/edgeTilingManager.ts
+++ b/src/components/tilingsystem/edgeTilingManager.ts
@@ -8,7 +8,7 @@ import Settings from '@settings/settings';
 import { registerGObjectClass } from '@utils/gjs';
 
 const EDGE_TILING_OFFSET = 16;
-const TOP_EDGE_TILING_OFFSET = 8;
+const VERTICAL_EDGE_TILING_OFFSET = 8;
 const QUARTER_PERCENTAGE = 0.5;
 
 @registerGObjectClass
@@ -124,11 +124,11 @@ export default class EdgeTilingManager extends GObject.Object {
     }): boolean {
         return (
             pointerPos.x <= this._workArea.x + EDGE_TILING_OFFSET ||
-            pointerPos.y <= this._workArea.y + TOP_EDGE_TILING_OFFSET ||
+            pointerPos.y <= this._workArea.y + VERTICAL_EDGE_TILING_OFFSET ||
             pointerPos.x >=
                 this._workArea.x + this._workArea.width - EDGE_TILING_OFFSET ||
             pointerPos.y >=
-                this._workArea.y + this._workArea.height - EDGE_TILING_OFFSET
+                this._workArea.y + this._workArea.height - VERTICAL_EDGE_TILING_OFFSET
         );
     }
 

--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -695,6 +695,14 @@ export class TilingManager {
                 this._selectedTilesPreview.close(true);
             }
 
+            if (Settings.SNAP_ASSIST) {
+                this._snapAssist.onMovingWindow(
+                    window,
+                    true,
+                    currPointerPos,
+                );
+            }
+
             if (
                 Settings.ACTIVE_SCREEN_EDGES &&
                 !this._snapAssistingInfo.isSnapAssisting &&
@@ -704,19 +712,10 @@ export class TilingManager {
                     this._edgeTilingManager.startEdgeTiling(currPointerPos);
                 if (changed)
                     this._showEdgeTiling(window, rect, x, y, tilingLayout);
-                this._snapAssist.close(true);
             } else {
                 if (this._edgeTilingManager.isPerformingEdgeTiling()) {
                     this._selectedTilesPreview.close(true);
                     this._edgeTilingManager.abortEdgeTiling();
-                }
-
-                if (Settings.SNAP_ASSIST) {
-                    this._snapAssist.onMovingWindow(
-                        window,
-                        true,
-                        currPointerPos,
-                    );
                 }
             }
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1,5 +1,5 @@
 import { Gtk, Adw, Gio, GLib, Gdk, GObject } from '@gi.prefs';
-import Settings, { ActivationKey } from './settings/settings';
+import Settings, { ActivationKey, AssistantPosition } from './settings/settings';
 import { logger } from './utils/logger';
 import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 import Layout from '@components/layout/Layout';
@@ -179,6 +179,11 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
             Settings.KEY_SNAP_ASSIST,
             _('Enable Snap Assistant'),
             _('Move the window on top of the screen to snap assist it'),
+            this._buildAssistantPositionDropDown(
+                Settings.SNAP_ASSISTANT_POSITION,
+                (val: AssistantPosition) =>
+                    (Settings.SNAP_ASSISTANT_POSITION = val),
+            ),
         );
         behaviourGroup.add(snapAssistRow);
 
@@ -1054,6 +1059,35 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
                 index < 0 || index >= activationKeys.length
                     ? ActivationKey.NONE
                     : activationKeys[index];
+            onChange(selected);
+        });
+        if (styleClass) dropdown.add_css_class(styleClass);
+        dropdown.set_vexpand(false);
+        dropdown.set_valign(Gtk.Align.CENTER);
+        return dropdown;
+    }
+
+    _buildAssistantPositionDropDown(
+        initialValue: AssistantPosition,
+        onChange: (_: AssistantPosition) => void,
+        styleClass?: string,
+    ) {
+        const options = new Gtk.StringList();
+        const assistantPositions = [
+            AssistantPosition.TOP,
+            AssistantPosition.BOTTOM,
+        ];
+        assistantPositions.forEach((p) => options.append(AssistantPosition[p]));
+        const dropdown = new Gtk.DropDown({
+            model: options,
+            selected: initialValue,
+        });
+        dropdown.connect('notify::selected-item', (dd: Gtk.DropDown) => {
+            const index = dd.get_selected();
+            const selected =
+                index < 0 || index >= assistantPositions.length
+                    ? AssistantPostion.TOP
+                    : assistantPositions[index];
             onChange(selected);
         });
         if (styleClass) dropdown.add_css_class(styleClass);

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -9,6 +9,11 @@ export enum ActivationKey {
     SUPER,
 }
 
+export enum AssistantPosition {
+    TOP = 0,
+    BOTTOM,
+}
+
 /** ------------- Utility functions ------------- */
 function get_string(key: string): string {
     return (
@@ -99,6 +104,7 @@ export default class Settings {
     static KEY_ACTIVE_SCREEN_EDGES = 'active-screen-edges';
     static KEY_TOP_EDGE_MAXIMIZE = 'top-edge-maximize';
     static KEY_OVERRIDE_WINDOW_MENU = 'override-window-menu';
+    static KEY_SNAP_ASSISTANT_POSITION = 'snap-assistant-position';
     static KEY_SNAP_ASSISTANT_THRESHOLD = 'snap-assistant-threshold';
     static KEY_ENABLE_WINDOW_BORDER = 'enable-window-border';
     static KEY_INNER_GAPS = 'inner-gaps';
@@ -340,6 +346,14 @@ export default class Settings {
 
     static set OVERRIDE_WINDOW_MENU(val: boolean) {
         set_boolean(Settings.KEY_OVERRIDE_WINDOW_MENU, val);
+    }
+
+    static get SNAP_ASSISTANT_POSITION(): AssistantPosition {
+        return get_number(Settings.KEY_SNAP_ASSISTANT_POSITION);
+    }
+
+    static set SNAP_ASSISTANT_POSITION(val: AssistantPosition) {
+        set_number(Settings.KEY_SNAP_ASSISTANT_POSITION, val);
     }
 
     static get SNAP_ASSISTANT_THRESHOLD(): number {


### PR DESCRIPTION
It would be great to put snap assistant at bottom. because GNOME has a top panel but no bottom panel by default, and top-center is already for maximize.