### PR TITLE
Implement configurable edge tiling offset.

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
@@ -127,6 +127,11 @@
             <summary>Quarter tiling threshold</summary>
             <description>Threshold to trigger quarter tiling.</description>
         </key>
+        <key name="edge-tiling-offset" type="u">
+            <default>16</default>
+            <summary>Edge tiling offset</summary>
+            <description>Offset to trigger edge tiling (left and right edge).</description>
+        </key>
         <key name="enable-window-border" type="b">
             <default>false</default>
             <summary>Enable window border</summary>

--- a/src/components/tilingsystem/edgeTilingManager.ts
+++ b/src/components/tilingsystem/edgeTilingManager.ts
@@ -8,7 +8,6 @@ import Settings from '@settings/settings';
 import { registerGObjectClass } from '@utils/gjs';
 import { logger } from '@utils/logger';
 
-const EDGE_TILING_OFFSET = 16;
 const TOP_EDGE_TILING_OFFSET = 8;
 const QUARTER_PERCENTAGE = 0.5;
 
@@ -26,10 +25,20 @@ export default class EdgeTilingManager extends GObject.Object {
                 50,
                 40,
             ),
+            edgeTilingOffset: GObject.ParamSpec.uint(
+                'edgeTilingOffset',
+                'edgeTilingOffset',
+                'Offset to trigger edge tiling',
+                GObject.ParamFlags.READWRITE,
+                1,
+                250,
+                16,
+            ),
         },
     };
     private _workArea: Mtk.Rectangle;
     private _quarterActivationPercentage: number;
+    private _edgeTilingOffset: number;
 
     // activation zones
     private _topLeft: Mtk.Rectangle;
@@ -61,11 +70,21 @@ export default class EdgeTilingManager extends GObject.Object {
             this,
             'quarterActivationPercentage',
         );
+        this._edgeTilingOffset = Settings.EDGE_TILING_OFFSET;
+        Settings.bind(
+            Settings.KEY_EDGE_TILING_OFFSET,
+            this,
+            'edgeTilingOffset',
+        );
     }
 
     private set quarterActivationPercentage(value: number) {
         this._quarterActivationPercentage = value / 100;
         this._updateActivationZones();
+    }
+
+    private set edgeTilingOffset(value: number) {
+        this._edgeTilingOffset = value;
     }
 
     public set workarea(newWorkArea: Mtk.Rectangle) {
@@ -127,12 +146,12 @@ export default class EdgeTilingManager extends GObject.Object {
         y: number;
     }): boolean {
         return (
-            pointerPos.x <= this._workArea.x + EDGE_TILING_OFFSET ||
+            pointerPos.x <= this._workArea.x + this._edgeTilingOffset ||
             pointerPos.y <= this._workArea.y + TOP_EDGE_TILING_OFFSET ||
             pointerPos.x >=
-                this._workArea.x + this._workArea.width - EDGE_TILING_OFFSET ||
+                this._workArea.x + this._workArea.width - this._edgeTilingOffset ||
             pointerPos.y >=
-                this._workArea.y + this._workArea.height - EDGE_TILING_OFFSET
+                this._workArea.y + this._workArea.height - this._edgeTilingOffset
         );
     }
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -298,6 +298,26 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
         );
         activeScreenEdgesGroup.add(quarterTiling);
 
+        const edgeTilingOffset = this._buildScaleRow(
+            _('Edge tiling offset'),
+            _(
+                'Offset from the screen edge to trigger edge tiling (in pixels)',
+            ),
+            (sc: Gtk.Scale) => {
+                Settings.EDGE_TILING_OFFSET = sc.get_value();
+            },
+            Settings.EDGE_TILING_OFFSET,
+            1,
+            250,
+            1,
+        );
+        Settings.bind
+            (Settings.KEY_ACTIVE_SCREEN_EDGES,
+            edgeTilingOffset,
+            'sensitive',
+        );
+        activeScreenEdgesGroup.add(edgeTilingOffset);
+
         prefsPage.add(activeScreenEdgesGroup);
 
         // Windows suggestions section

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -111,6 +111,7 @@ export default class Settings {
     static KEY_ENABLE_SMART_WINDOW_BORDER_RADIUS =
         'enable-smart-window-border-radius';
     static KEY_QUARTER_TILING_THRESHOLD = 'quarter-tiling-threshold';
+    static KEY_EDGE_TILING_OFFSET = 'edge-tiling-offset';
     static KEY_ENABLE_TILING_SYSTEM_WINDOWS_SUGGESTIONS =
         'enable-tiling-system-windows-suggestions';
     static KEY_ENABLE_SNAP_ASSISTANT_WINDOWS_SUGGESTIONS =
@@ -356,6 +357,14 @@ export default class Settings {
 
     static set QUARTER_TILING_THRESHOLD(val: number) {
         set_unsigned_number(Settings.KEY_QUARTER_TILING_THRESHOLD, val);
+    }
+
+    static get EDGE_TILING_OFFSET(): number {
+        return get_unsigned_number(Settings.KEY_EDGE_TILING_OFFSET);
+    }
+
+    static set EDGE_TILING_OFFSET(val: number) {
+        set_unsigned_number(Settings.KEY_EDGE_TILING_OFFSET, val);
     }
 
     static get WINDOW_BORDER_COLOR(): string {


### PR DESCRIPTION
This implements new option edge-tiling-offset which is used when determining when to activate edge tiling functionality. 

This is especially useful on multi-monitor setup where you have to be accurate where you throw your windows when trying to edge tile. Configuring a larger area gives more room for error on the area between horizontal monitors. This does not include logic for fixing the same issue on vertical layouts.

This is a simple approach but still useful to me.