### PR TITLE
Implement option to restrict directional navigation focus to tiled windows

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
@@ -72,6 +72,11 @@
             <summary>Enable next/previous window focus to wrap around</summary>
             <description>When focusing next or previous window, wrap around at the window edge</description>
         </key>
+        <key name="enable-directional-focus-tiled-only" type="b">
+            <default>false</default>
+            <summary>Restrict directional focus to tiled windows</summary>
+            <description>When using directional focus navigation, only consider tiled windows</description>
+        </key>
         <key name="resize-complementing-windows" type="b">
             <default>true</default>
             <summary>Enable auto-resize of the complementing tiled windows</summary>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -550,10 +550,16 @@ export default class TilingShellExtension extends Extension {
         const windowList = filterUnfocusableWindows(
             focus_window.get_workspace().list_windows(),
         );
+        const onlyTiledWindows = Settings.ENABLE_DIRECTIONAL_FOCUS_TILED_ONLY;
 
         windowList
             .filter((win) => {
                 if (win === focus_window || win.minimized) return false;
+                if (
+                    onlyTiledWindows &&
+                    (win as ExtendedWindow).assignedTile === undefined
+                )
+                    return false;
 
                 const winRect = win.get_frame_rect();
                 switch (direction) {

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -734,6 +734,15 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
         );
         keybindingsGroup.add(wrapAroundRow);
 
+        const directionalFocusTiledWindows = this._buildSwitchRow(
+            Settings.KEY_ENABLE_DIRECTIONAL_FOCUS_TILED_ONLY,
+            _('Restrict directional focus to tiled windows'),
+            _(
+                'When using directional focus navigation, only consider tiled windows',
+            ),
+        );
+        keybindingsGroup.add(directionalFocusTiledWindows);
+
         // Import/export/reset section
         const importExportGroup = new Adw.PreferencesGroup({
             title: _('Import, export and reset'),

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -90,6 +90,8 @@ export default class Settings {
     static KEY_SPAN_MULTIPLE_TILES = 'enable-span-multiple-tiles';
     static KEY_RESTORE_WINDOW_ORIGINAL_SIZE = 'restore-window-original-size';
     static KEY_WRAPAROUND_FOCUS = 'enable-wraparound-focus';
+    static KEY_ENABLE_DIRECTIONAL_FOCUS_TILED_ONLY =
+        'enable-directional-focus-tiled-only';
     static KEY_RESIZE_COMPLEMENTING_WINDOWS = 'resize-complementing-windows';
     static KEY_ENABLE_BLUR_SNAP_ASSISTANT = 'enable-blur-snap-assistant';
     static KEY_ENABLE_BLUR_SELECTED_TILEPREVIEW =
@@ -276,6 +278,14 @@ export default class Settings {
 
     static set WRAPAROUND_FOCUS(val: boolean) {
         set_boolean(Settings.KEY_WRAPAROUND_FOCUS, val);
+    }
+
+    static get ENABLE_DIRECTIONAL_FOCUS_TILED_ONLY(): boolean {
+        return get_boolean(Settings.KEY_ENABLE_DIRECTIONAL_FOCUS_TILED_ONLY);
+    }
+
+    static set ENABLE_DIRECTIONAL_FOCUS_TILED_ONLY(val: boolean) {
+        set_boolean(Settings.KEY_ENABLE_DIRECTIONAL_FOCUS_TILED_ONLY, val);
     }
 
     static get RESIZE_COMPLEMENTING_WINDOWS(): boolean {


### PR DESCRIPTION
Implements #363. Suggestions are welcome :)

A new boolean option is added. When switched off and on:
<video src="https://github.com/user-attachments/assets/ba60e838-1baf-4a1e-a692-eb9102554928">