### PR TITLE
When moving focus to tile with multiple windows, choose top of stack

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -599,6 +599,7 @@ export default class TilingShellExtension extends Extension {
 
         let bestWindow: Meta.Window | undefined;
         let bestWindowDistance = -1;
+        let bestWindowStackIndex = -1;
 
         const focusWindowRect = focus_window.get_frame_rect();
         const focusWindowCenter = {
@@ -610,6 +611,9 @@ export default class TilingShellExtension extends Extension {
             focus_window.get_workspace().list_windows(),
         );
         const onlyTiledWindows = Settings.ENABLE_DIRECTIONAL_FOCUS_TILED_ONLY;
+
+        const stackingOrder =
+            global.display.sort_windows_by_stacking(windowList);
 
         windowList
             .filter((win) => {
@@ -645,14 +649,17 @@ export default class TilingShellExtension extends Extension {
                     focusWindowCenter,
                 );
 
+                const winStackIndex = stackingOrder.indexOf(win);
+
                 if (
                     !bestWindow ||
                     euclideanDistance < bestWindowDistance ||
                     (euclideanDistance === bestWindowDistance &&
-                        bestWindow.get_frame_rect().y > winRect.y)
+                        winStackIndex > bestWindowStackIndex)
                 ) {
                     bestWindow = win;
                     bestWindowDistance = euclideanDistance;
+                    bestWindowStackIndex = winStackIndex;
                 }
             });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -615,8 +615,9 @@ export default class TilingShellExtension extends Extension {
         const stackingOrder =
             global.display.sort_windows_by_stacking(windowList);
 
-        windowList
-            .filter((win) => {
+        stackingOrder
+            .map((win, winStackIndex) => ({ win, winStackIndex }))
+            .filter(({ win }) => {
                 if (win === focus_window || win.minimized) return false;
                 if (
                     onlyTiledWindows &&
@@ -637,7 +638,7 @@ export default class TilingShellExtension extends Extension {
                 }
                 return false;
             })
-            .forEach((win) => {
+            .forEach(({ win, winStackIndex }) => {
                 const winRect = win.get_frame_rect();
                 const winCenter = {
                     x: winRect.x + winRect.width / 2,
@@ -648,8 +649,6 @@ export default class TilingShellExtension extends Extension {
                     winCenter,
                     focusWindowCenter,
                 );
-
-                const winStackIndex = stackingOrder.indexOf(win);
 
                 if (
                     !bestWindow ||

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -633,8 +633,9 @@ export default class TilingShellExtension extends Extension {
         const stackingOrder =
             global.display.sort_windows_by_stacking(windowList);
 
-        windowList
-            .filter((win) => {
+        stackingOrder
+            .map((win, winStackIndex) => ({ win, winStackIndex }))
+            .filter(({ win }) => {
                 if (win === focus_window || win.minimized) return false;
                 if (
                     onlyTiledWindows &&
@@ -655,7 +656,7 @@ export default class TilingShellExtension extends Extension {
                 }
                 return false;
             })
-            .forEach((win) => {
+            .forEach(({ win, winStackIndex }) => {
                 const winRect = win.get_frame_rect();
                 const winCenter = {
                     x: winRect.x + winRect.width / 2,
@@ -666,8 +667,6 @@ export default class TilingShellExtension extends Extension {
                     winCenter,
                     focusWindowCenter,
                 );
-
-                const winStackIndex = stackingOrder.indexOf(win);
 
                 if (
                     !bestWindow ||

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -617,6 +617,7 @@ export default class TilingShellExtension extends Extension {
 
         let bestWindow: Meta.Window | undefined;
         let bestWindowDistance = -1;
+        let bestWindowStackIndex = -1;
 
         const focusWindowRect = focus_window.get_frame_rect();
         const focusWindowCenter = {
@@ -628,6 +629,9 @@ export default class TilingShellExtension extends Extension {
             focus_window.get_workspace().list_windows(),
         );
         const onlyTiledWindows = Settings.ENABLE_DIRECTIONAL_FOCUS_TILED_ONLY;
+
+        const stackingOrder =
+            global.display.sort_windows_by_stacking(windowList);
 
         windowList
             .filter((win) => {
@@ -663,14 +667,17 @@ export default class TilingShellExtension extends Extension {
                     focusWindowCenter,
                 );
 
+                const winStackIndex = stackingOrder.indexOf(win);
+
                 if (
                     !bestWindow ||
                     euclideanDistance < bestWindowDistance ||
                     (euclideanDistance === bestWindowDistance &&
-                        bestWindow.get_frame_rect().y > winRect.y)
+                        winStackIndex > bestWindowStackIndex)
                 ) {
                     bestWindow = win;
                     bestWindowDistance = euclideanDistance;
+                    bestWindowStackIndex = winStackIndex;
                 }
             });
 


### PR DESCRIPTION
This makes the keybindings for moving focus usable for people who habitually have multiple windows on one tile. Previously, the order in which they were selected was arbitrary, as far as I could tell. This was very annoying, because it could mean that switching right then left would often hide the original window in favour of one that was stacked behind it. Usually I'd just fall back to alt-tab, even though moving by direction should be much more intuitive.

I'm not a heavy user of stacking, though I might be more inclined if we could switch between stacked windows more easily (see #377 and #165, though on the latter I agree really that we wouldn't want any visual clutter). But I do often have multiple VSCode windows open in the same tile, and in this case, I can use gnome's keybinding for switching between windows of the same program instead.

This was shamelessly vibe-coded with OpenCode and Claude Opus 4.5. Hopefully that's okay. If nothing else, it serves as a feature request and some indication of how it could be implemented. And anyway, I'm using it right now and it does exactly what I want!

The behaviour for choosing between partially-overlapping windows could maybe still be improved, but I don't personally care about that.