### PR TITLE
implement topology persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean:resources": "rm -rf ./dist/*.gresource; rm -rf ./dist_legacy/*.gresource",
     "build:package": "npm run clean:package; npm run build && cd ./dist && zip -x 'schemas/gschemas.compiled' -qr ../tilingshell@ferrarodomenico.com.zip * && cd ../dist_legacy && zip -qr ../GNOME.42-44.tilingshell@ferrarodomenico.com.zip *",
     "clean:package": "rm -rf './dist/tilingshell@ferrarodomenico.com.zip'; rm -rf './dist_legacy/tilingshell@ferrarodomenico.com.zip'",
-    "install:extension": "mkdir -p ~/.local/share/gnome-shell/extensions/tilingshell@ferrarodomenico.com && cp ./dist$([ $(gnome-shell --version | grep -o -E '[0-9]+' | head -n 1) -le 44 ] && echo '_legacy')/* ~/.local/share/gnome-shell/extensions/tilingshell@ferrarodomenico.com/ -r",
+    "install:extension": "npm run build:schema && mkdir -p ~/.local/share/gnome-shell/extensions/tilingshell@ferrarodomenico.com && cp ./dist$([ $(gnome-shell --version | grep -o -E '[0-9]+' | head -n 1) -le 44 ] && echo '_legacy')/* ~/.local/share/gnome-shell/extensions/tilingshell@ferrarodomenico.com/ -r",
     "wayland-session": "dbus-run-session -- env MUTTER_DEBUG_NUM_DUMMY_MONITORS=1 MUTTER_DEBUG_DUMMY_MODE_SPECS=1920x1080 gnome-shell --nested --wayland",
     "dev:wayland": "npm run build && npm run install:extension && npm run wayland-session",
     "build:translations": "for file in $(ls translations/*.po); do mkdir -p resources/locale/$(basename $file .po)/LC_MESSAGES; msgfmt -c $file -o resources/locale/$(basename $file .po)/LC_MESSAGES/tilingshell.mo; done",

--- a/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
@@ -67,6 +67,11 @@
             <summary>Selected layouts</summary>
             <description>Each monitor's active layout used by the monitor tiling manager.</description>
         </key>
+        <key name="selected-layouts-by-topology" type="s">
+            <default>'{}'</default>
+            <summary>Selected layouts by topology</summary>
+            <description>JSON map of monitor topology signatures to selected layouts.</description>
+        </key>
         <key name="restore-window-original-size" type="b">
             <default>true</default>
             <summary>Restore window size</summary>

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -115,6 +115,9 @@ export default class Settings {
     static KEY_TILE_PREVIEW_ANIMATION_TIME = 'tile-preview-animation-time';
     static KEY_SETTING_LAYOUTS_JSON = 'layouts-json';
     static KEY_SETTING_SELECTED_LAYOUTS = 'selected-layouts';
+    static KEY_SETTING_SELECTED_LAYOUTS_BY_TOPOLOGY =
+        'selected-layouts-by-topology';
+
     static KEY_WINDOW_BORDER_WIDTH = 'window-border-width';
     static KEY_ENABLE_SMART_WINDOW_BORDER_RADIUS = 'enable-smart-window-border-radius';
     static KEY_QUARTER_TILING_THRESHOLD = 'quarter-tiling-threshold';
@@ -582,6 +585,37 @@ export default class Settings {
         return result;
     }
 
+    static get_selected_layouts_by_topology(): Record<string, string[][]> {
+        try {
+            const raw =
+                this._settings?.get_string(
+                    Settings.KEY_SETTING_SELECTED_LAYOUTS_BY_TOPOLOGY,
+                ) || '{}';
+            const parsed = JSON.parse(raw) as Record<string, unknown>;
+            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+                throw new Error('Invalid topology map');
+
+            const result: Record<string, string[][]> = {};
+            for (const [key, value] of Object.entries(parsed)) {
+                if (!Array.isArray(value))
+                    throw new Error('Invalid topology map');
+                result[key] = value.map((workspace) => {
+                    if (!Array.isArray(workspace))
+                        throw new Error('Invalid topology map');
+                    return workspace.map((layoutId) => {
+                        if (typeof layoutId !== 'string')
+                            throw new Error('Invalid topology map');
+                        return layoutId;
+                    });
+                });
+            }
+            return result;
+        } catch (_unused) {
+            this.reset_selected_layouts_by_topology();
+            return {};
+        }
+    }
+
     static reset_layouts_json() {
         this.save_layouts_json([
             new Layout(
@@ -710,6 +744,27 @@ export default class Settings {
         this._settings?.set_value(
             Settings.KEY_SETTING_SELECTED_LAYOUTS,
             result,
+        );
+    }
+
+    static save_selected_layouts_by_topology(
+        topologyMap: Record<string, string[][]>,
+    ) {
+        if (Object.keys(topologyMap).length === 0) {
+            this._settings?.reset(
+                Settings.KEY_SETTING_SELECTED_LAYOUTS_BY_TOPOLOGY,
+            );
+            return;
+        }
+        this._settings?.set_string(
+            Settings.KEY_SETTING_SELECTED_LAYOUTS_BY_TOPOLOGY,
+            JSON.stringify(topologyMap),
+        );
+    }
+
+    static reset_selected_layouts_by_topology() {
+        this._settings?.reset(
+            Settings.KEY_SETTING_SELECTED_LAYOUTS_BY_TOPOLOGY,
         );
     }
 

--- a/src/utils/globalState.ts
+++ b/src/utils/globalState.ts
@@ -157,7 +157,7 @@ export default class GlobalState extends GObject.Object {
                     to_be_saved.push(monitors_layouts);
                 }
 
-                Settings.save_selected_layouts(to_be_saved);
+                this._persistSelectedLayouts(to_be_saved);
             },
         );
 
@@ -179,7 +179,7 @@ export default class GlobalState extends GObject.Object {
                     newMap.set(ws, monitors_layouts);
                     to_be_saved.push(monitors_layouts);
                 }
-                Settings.save_selected_layouts(to_be_saved);
+                this._persistSelectedLayouts(to_be_saved);
 
                 this._selected_layouts.clear();
                 this._selected_layouts = newMap;
@@ -199,7 +199,27 @@ export default class GlobalState extends GObject.Object {
 
     public validate_selected_layouts() {
         const n_monitors = Main.layoutManager.monitors.length;
-        const old_selected_layouts = Settings.get_selected_layouts();
+        const currentSignatures = this._getMonitorSignatures();
+        const topologyMatch = this._findTopologyMatch(
+            Settings.get_selected_layouts_by_topology(),
+            currentSignatures,
+        );
+        const defaultLayoutId = this._layouts[0].id;
+        let old_selected_layouts =
+            topologyMatch?.selections ?? Settings.get_selected_layouts();
+        if (topologyMatch) {
+            const fromKey = this._buildTopologyKey(
+                topologyMatch.signatures,
+            );
+            if (fromKey !== this._buildTopologyKey(currentSignatures)) {
+                old_selected_layouts = this._remapSelections(
+                    old_selected_layouts,
+                    topologyMatch.signatures,
+                    currentSignatures,
+                    defaultLayoutId,
+                );
+            }
+        }
         for (let i = 0; i < global.workspaceManager.get_n_workspaces(); i++) {
             const ws = global.workspaceManager.get_workspace_by_index(i);
             if (!ws) continue;
@@ -207,7 +227,7 @@ export default class GlobalState extends GObject.Object {
             const monitors_layouts =
                 i < old_selected_layouts.length ? old_selected_layouts[i] : [];
             while (monitors_layouts.length < n_monitors)
-                monitors_layouts.push(this._layouts[0].id);
+                monitors_layouts.push(defaultLayoutId);
             while (monitors_layouts.length > n_monitors) monitors_layouts.pop();
 
             monitors_layouts.forEach((_, ind) => {
@@ -236,7 +256,103 @@ export default class GlobalState extends GObject.Object {
             to_be_saved.push(monitors_layouts);
         }
 
-        Settings.save_selected_layouts(to_be_saved);
+        this._persistSelectedLayouts(to_be_saved);
+    }
+
+    private _persistSelectedLayouts(selectedLayouts: string[][]) {
+        Settings.save_selected_layouts(selectedLayouts);
+        const topologyMap = Settings.get_selected_layouts_by_topology();
+        const topologyKey = this._buildTopologyKey(
+            this._getMonitorSignatures(),
+        );
+        if (selectedLayouts.length === 0) {
+            delete topologyMap[topologyKey];
+        } else {
+            topologyMap[topologyKey] = selectedLayouts;
+        }
+        Settings.save_selected_layouts_by_topology(topologyMap);
+    }
+
+    private _getMonitorSignatures(): string[] {
+        return Main.layoutManager.monitors.map((monitor) => {
+            const geometryScale =
+                (monitor as { geometryScale?: number }).geometryScale ??
+                (monitor as { geometry_scale?: number }).geometry_scale ??
+                (monitor as { scale?: number }).scale ??
+                (monitor as { scaleFactor?: number }).scaleFactor ??
+                1;
+            return `${monitor.x},${monitor.y},${monitor.width},${monitor.height},${geometryScale}`;
+        });
+    }
+
+    private _buildTopologyKey(signatures: string[]): string {
+        return signatures.join('|');
+    }
+
+    private _findTopologyMatch(
+        topologyMap: Record<string, string[][]>,
+        currentSignatures: string[],
+    ): { selections: string[][]; signatures: string[] } | null {
+        const exactKey = this._buildTopologyKey(currentSignatures);
+        if (topologyMap[exactKey]) {
+            return {
+                selections: topologyMap[exactKey],
+                signatures: currentSignatures,
+            };
+        }
+
+        for (const [key, selections] of Object.entries(topologyMap)) {
+            const signatures = key.length > 0 ? key.split('|') : [];
+            if (this._signaturesMatch(signatures, currentSignatures)) {
+                return {
+                    selections,
+                    signatures,
+                };
+            }
+        }
+
+        return null;
+    }
+
+    private _signaturesMatch(
+        source: string[],
+        target: string[],
+    ): boolean {
+        if (source.length !== target.length) return false;
+        const counts = new Map<string, number>();
+        source.forEach((signature) => {
+            counts.set(signature, (counts.get(signature) ?? 0) + 1);
+        });
+        for (const signature of target) {
+            const count = counts.get(signature);
+            if (!count) return false;
+            if (count === 1) counts.delete(signature);
+            else counts.set(signature, count - 1);
+        }
+        return counts.size === 0;
+    }
+
+    private _remapSelections(
+        selections: string[][],
+        fromSignatures: string[],
+        toSignatures: string[],
+        defaultLayoutId: string,
+    ): string[][] {
+        const indexMap = toSignatures.map((signature) =>
+            fromSignatures.indexOf(signature),
+        );
+        return selections.map((workspaceSelections) => {
+            const remapped: string[] = [];
+            for (let i = 0; i < toSignatures.length; i++) {
+                const fromIndex = indexMap[i];
+                const layoutId =
+                    fromIndex >= 0
+                        ? workspaceSelections?.[fromIndex]
+                        : undefined;
+                remapped.push(layoutId ?? defaultLayoutId);
+            }
+            return remapped;
+        });
     }
 
     get layouts(): Layout[] {
@@ -365,6 +481,6 @@ export default class GlobalState extends GObject.Object {
             }
         }
 
-        Settings.save_selected_layouts(selected);
+        this._persistSelectedLayouts(selected);
     }
 }


### PR DESCRIPTION
Hey mate, 

Give this a try. 

Been working for a while now for me, implemented using gnome geometry, and includes fallback to the existing logic. 

New per‑topology storage key in the schema. GSettings key `selected-layouts-by-topology` stores json maps to remember layouts per topology instead of just a single global set.

On startup / sync, it:

    calculates the current monitor topology key,
    loads the topology map,
    uses the topology‑specific layouts if available,
    otherwise falls back to the global selected-layouts,
    remapping layouts across monitors using signature matching to preserve selection when monitor order changes.