### PR TITLE
fix: alt-tab race condition and signal handler leak

### DIFF
--- a/src/components/altTab/MetaWindowGroup.ts
+++ b/src/components/altTab/MetaWindowGroup.ts
@@ -5,6 +5,7 @@ import { Meta } from '../../gi/ext';
  */
 export default class MetaWindowGroup {
     private _windows: Meta.Window[];
+    private _signalIds: number[];
     private _unmanagedCounter: number; // count how many windows are unmanaged
     private _unmanagedEventHandler: (() => void) | null;
 
@@ -17,7 +18,7 @@ export default class MetaWindowGroup {
         this._unmanagedCounter = 0;
         this._unmanagedEventHandler = null;
 
-        this._windows.forEach((win) =>
+        this._signalIds = this._windows.map((win) =>
             win.connect('unmanaged', () => {
                 this._unmanagedCounter++;
                 if (
@@ -75,5 +76,14 @@ export default class MetaWindowGroup {
 
     public onAllWindowsUnmanaged(fn: () => void) {
         this._unmanagedEventHandler = fn;
+    }
+
+    public destroy() {
+        this._windows.forEach((win, i) => {
+            if (this._signalIds[i])
+                win.disconnect(this._signalIds[i]);
+        });
+        this._signalIds = [];
+        this._unmanagedEventHandler = null;
     }
 }

--- a/src/components/altTab/MultipleWindowsIcon.ts
+++ b/src/components/altTab/MultipleWindowsIcon.ts
@@ -59,6 +59,7 @@ export default class MultipleWindowsIcon extends LayoutWidget<TilePreviewWithWin
         });
         // gnome shell accesses to this window, we need to abstract operations to work for a group of windows instead of one
         this._window = new MetaWindowGroup(params.windows);
+        this.connect('destroy', () => this._window.destroy());
 
         // if the rightmost tiled window doesn't reach the end of the icon
         // let's shrink the width to make it happen

--- a/src/components/altTab/overriddenAltTab.ts
+++ b/src/components/altTab/overriddenAltTab.ts
@@ -59,9 +59,14 @@ export default class OverriddenAltTab {
         this._switcherList._list.get_layout_manager().homogeneous = false;
         this._switcherList._squareItems = false;
 
-        // Call original show function
+        // Call original show function. Note: show() may synchronously
+        // destroy the popup if the modifier key was already released
+        // (see GNOME bug 596695), so we must check liveness afterward.
         const oldFunction = OverriddenAltTab._old_show?.bind(this);
         const res = !oldFunction || oldFunction(backward, binding, mask);
+
+        // If the popup was destroyed during show(), bail out.
+        if (!this._switcherList || !this._items?.length) return res;
 
         const tiledWindows: Meta.Window[] = (
             this._getWindowList() as Meta.Window[]


### PR DESCRIPTION
Fix two issues in the alt-tab override:

1. Guard against the popup being synchronously destroyed during `show()` when the modifier key is released before the grab completes (GNOME#596695). This prevents hundreds of "already disposed" and `clutter_actor_add_child` assertion errors on every fast alt-tab.

2. Store and disconnect `unmanaged` signal handlers in `MetaWindowGroup` so they don't leak for the lifetime of the shell process.