### PR TITLE
feat: add option to sync layout across all workspaces

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
@@ -208,6 +208,12 @@
             <description>Controls how windows snap to screen edges:\n'default' (corners snap to quarters, edges to halves),\n'adaptive' (snap to layout tiles by column),\n'granular' (snap to exact tile under cursor).</description>
         </key>
 
+        <key name="sync-layout-across-workspaces" type="b">
+            <default>false</default>
+            <summary>Sync layout across workspaces</summary>
+            <description>When a layout is selected, apply it to all workspaces instead of just the active one.</description>
+        </key>
+
         <!-- keybindings -->
 		<key type="as" name="move-window-right">
 			<default><![CDATA[['<Super>Right']]]></default>

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -320,6 +320,15 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
         );
         behaviourGroup.add(raiseTogetherRow);
 
+        const syncLayoutRow = this._buildSwitchRow(
+            Settings.KEY_SYNC_LAYOUT_ACROSS_WORKSPACES,
+            _('Sync layout across workspaces'),
+            _(
+                'When a layout is selected, apply it to all workspaces instead of just the active one',
+            ),
+        );
+        behaviourGroup.add(syncLayoutRow);
+
         // Screen Edges section
         const activeScreenEdgesGroup = new Adw.PreferencesGroup({
             title: _('Screen Edges'),

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -123,6 +123,7 @@ export default class Settings {
     static KEY_ENABLE_SNAP_ASSISTANT_WINDOWS_SUGGESTIONS = 'enable-snap-assistant-windows-suggestions';
     static KEY_ENABLE_SCREEN_EDGES_WINDOWS_SUGGESTIONS = 'enable-screen-edges-windows-suggestions';
     static KEY_EDGE_TILING_MODE = 'edge-tiling-mode';
+    static KEY_SYNC_LAYOUT_ACROSS_WORKSPACES = 'sync-layout-across-workspaces';
 
     static SETTING_MOVE_WINDOW_RIGHT = 'move-window-right';
     static SETTING_MOVE_WINDOW_LEFT = 'move-window-left';
@@ -504,6 +505,14 @@ export default class Settings {
 
     static set EDGE_TILING_MODE(val: EdgeTilingMode) {
         set_string(Settings.KEY_EDGE_TILING_MODE, val);
+    }
+
+    static get SYNC_LAYOUT_ACROSS_WORKSPACES(): boolean {
+        return get_boolean(Settings.KEY_SYNC_LAYOUT_ACROSS_WORKSPACES);
+    }
+
+    static set SYNC_LAYOUT_ACROSS_WORKSPACES(val: boolean) {
+        set_boolean(Settings.KEY_SYNC_LAYOUT_ACROSS_WORKSPACES, val);
     }
 
     static get_inner_gaps(scaleFactor: number = 1): {

--- a/src/utils/globalState.ts
+++ b/src/utils/globalState.ts
@@ -331,37 +331,35 @@ export default class GlobalState extends GObject.Object {
         layoutToSelectId: string,
         monitorIndex: number,
     ) {
-        // get the currently selected layouts
         const selected = Settings.get_selected_layouts();
-        // select the layout for the given monitor
-        selected[global.workspaceManager.get_active_workspace_index()][
-            monitorIndex
-        ] = layoutToSelectId;
 
-        // if there are 2 or more workspaces, if the last workspace is empty
-        // it must follow the layout of the second-last workspace
-        // if we changed the second-last workspace we take care of changing
-        // the last workspace as well, if there aren't tiled windows (is empty)
-        const n_workspaces = global.workspaceManager.get_n_workspaces();
-        if (
-            global.workspaceManager.get_active_workspace_index() ===
-            n_workspaces - 2
-        ) {
-            const lastWs = global.workspaceManager.get_workspace_by_index(
-                n_workspaces - 1,
-            );
-            if (!lastWs) return;
+        if (Settings.SYNC_LAYOUT_ACROSS_WORKSPACES) {
+            for (let i = 0; i < selected.length; i++) {
+                selected[i][monitorIndex] = layoutToSelectId;
+            }
+        } else {
+            selected[global.workspaceManager.get_active_workspace_index()][
+                monitorIndex
+            ] = layoutToSelectId;
 
-            // check if there are tiled windows on that monitor and in the last workspace
-            const tiledWindows = getWindows(lastWs).find(
-                (win) =>
-                    (win as ExtendedWindow).assignedTile &&
-                    win.get_monitor() === monitorIndex,
-            );
-            if (!tiledWindows) {
-                // the last workspace, on that monitor, is empty
-                // select the same layout for last workspace as well
-                selected[lastWs.index()][monitorIndex] = layoutToSelectId;
+            const n_workspaces = global.workspaceManager.get_n_workspaces();
+            if (
+                global.workspaceManager.get_active_workspace_index() ===
+                n_workspaces - 2
+            ) {
+                const lastWs = global.workspaceManager.get_workspace_by_index(
+                    n_workspaces - 1,
+                );
+                if (!lastWs) return;
+
+                const tiledWindows = getWindows(lastWs).find(
+                    (win) =>
+                        (win as ExtendedWindow).assignedTile &&
+                        win.get_monitor() === monitorIndex,
+                );
+                if (!tiledWindows) {
+                    selected[lastWs.index()][monitorIndex] = layoutToSelectId;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Adds a new `sync-layout-across-workspaces` boolean setting (default: off)
- When enabled, selecting a layout on any workspace applies it to all workspaces for that monitor
- Toggle appears in the Behaviour section of extension preferences

## How it works

The sync logic is centralized in `GlobalState.setSelectedLayoutOfMonitor()` — when the setting is enabled, it iterates all workspace slots and sets the same layout. All existing callers (panel indicator click, keyboard layout cycling, snap-assist sync) get the behavior automatically with zero changes.

## Files changed

- `gschema.xml` — new boolean key
- `src/settings/settings.ts` — KEY constant + getter/setter
- `src/utils/globalState.ts` — sync branch in `setSelectedLayoutOfMonitor()`
- `src/prefs.ts` — toggle in Behaviour group

## Test plan

- [ ] Enable setting, select layout on workspace 1, switch to workspace 2 — same layout shown
- [ ] Multi-monitor: sync on monitor 1 doesn't affect monitor 2
- [ ] Keyboard cycle layouts with sync enabled — all workspaces update
- [ ] Disable setting — per-workspace behavior restored
- [ ] New workspace created while sync enabled — inherits synced layout
- [ ] Toggle appears in Behaviour section of preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)