### PR TITLE
feat: add Right Mouse Button as activation key

### DIFF
--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -582,6 +582,12 @@ export class TilingManager {
             case ActivationKey.SUPER:
                 mask = Clutter.ModifierType.SUPER_MASK;
                 break;
+            case ActivationKey.RIGHT_BUTTON:
+                // Clutter's native backend maps clutter_button=3 (RMB) to
+                // BUTTON2_MASK (see mutter src/backends/native/meta-seat-impl.c
+                // maskmap). BUTTON3_MASK is the middle button — do not use it.
+                mask = Clutter.ModifierType.BUTTON2_MASK;
+                break;
         }
         return (modifier & mask) === mask;
     }

--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -472,6 +472,7 @@ export class TilingManager {
         }
         this._signals.disconnect();
         this._isGrabbingWindow = false;
+        this._removeRmbFilterIfInstalled();
         this._snapAssistingInfo.update(undefined);
         this._edgeTilingManager.abortEdgeTiling();
         this._workspaceTilingLayout.forEach((tl) => tl.destroy());
@@ -558,6 +559,7 @@ export class TilingManager {
         }
 
         this._isGrabbingWindow = true;
+        this._installRmbFilterIfNeeded();
         this._movingWindowTimerId = GLib.timeout_add(
             GLib.PRIORITY_DEFAULT_IDLE,
             this._movingWindowTimerDuration,
@@ -883,6 +885,7 @@ export class TilingManager {
 
     private _onWindowGrabEnd(window: Meta.Window) {
         this._isGrabbingWindow = false;
+        this._removeRmbFilterIfInstalled();
         this._grabStartPosition = null;
 
         this._signals.disconnect(window);

--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -67,6 +67,8 @@ export class TilingManager {
     private _enableScaling: boolean;
 
     private _isGrabbingWindow: boolean;
+    private _rmbFilterId: number = 0;
+    private _rmbFilterInstalled: boolean = false;
     private _movingWindowTimerDuration: number = 15;
     private _lastCursorPos: { x: number; y: number } | null = null;
     private _grabStartPosition: { x: number; y: number } | null = null;
@@ -563,6 +565,82 @@ export class TilingManager {
         );
 
         this._onMovingWindow(window, grabOp);
+    }
+
+    private _anyActivationKeyIsRmb(): boolean {
+        return (
+            Settings.TILING_SYSTEM_ACTIVATION_KEY === ActivationKey.RIGHT_BUTTON ||
+            Settings.TILING_SYSTEM_DEACTIVATION_KEY === ActivationKey.RIGHT_BUTTON ||
+            Settings.SPAN_MULTIPLE_TILES_ACTIVATION_KEY === ActivationKey.RIGHT_BUTTON
+        );
+    }
+
+    private _rmbEventFilter(event: Clutter.Event, _actor: Clutter.Actor): boolean {
+        // Fast path: only act on button press/release.
+        const t = event.type();
+        if (
+            t !== Clutter.EventType.BUTTON_PRESS &&
+            t !== Clutter.EventType.BUTTON_RELEASE
+        ) {
+            return Clutter.EVENT_PROPAGATE;
+        }
+        // Swallow RMB press/release so Mutter's MOVING grab doesn't see them.
+        // CLUTTER_BUTTON_SECONDARY === 3.
+        if (event.get_button() === Clutter.BUTTON_SECONDARY) {
+            return Clutter.EVENT_STOP;
+        }
+        return Clutter.EVENT_PROPAGATE;
+    }
+
+    private _installRmbFilterIfNeeded(): void {
+        if (this._rmbFilterInstalled) return;
+        if (!this._anyActivationKeyIsRmb()) return;
+        // `Clutter.event_add_filter` / `event_remove_filter` are not always
+        // present in @girs/clutter type stubs. Cast to `any` to access them
+        // and runtime-check for availability below.
+        const addFilter = (Clutter as any).event_add_filter;
+        if (typeof addFilter !== 'function') {
+            console.error(
+                'tilingshell: Clutter.event_add_filter unavailable; ' +
+                'RIGHT_BUTTON activation key will not work on this version.',
+            );
+            return;
+        }
+        try {
+            this._rmbFilterId = addFilter(
+                global.stage,
+                this._rmbEventFilter.bind(this),
+            );
+            this._rmbFilterInstalled = this._rmbFilterId !== 0;
+            if (!this._rmbFilterInstalled) {
+                console.error(
+                    'tilingshell: Clutter.event_add_filter returned 0; ' +
+                    'RIGHT_BUTTON activation key will not work this drag.',
+                );
+            }
+        } catch (e) {
+            console.error('tilingshell: failed to install RMB filter: ' + e);
+            this._rmbFilterInstalled = false;
+            this._rmbFilterId = 0;
+        }
+    }
+
+    private _removeRmbFilterIfInstalled(): void {
+        if (!this._rmbFilterInstalled || this._rmbFilterId === 0) return;
+        const removeFilter = (Clutter as any).event_remove_filter;
+        if (typeof removeFilter !== 'function') {
+            // Defensive: should not happen if install succeeded.
+            this._rmbFilterInstalled = false;
+            this._rmbFilterId = 0;
+            return;
+        }
+        try {
+            removeFilter(this._rmbFilterId);
+        } catch (e) {
+            console.error('tilingshell: failed to remove RMB filter: ' + e);
+        }
+        this._rmbFilterInstalled = false;
+        this._rmbFilterId = 0;
     }
 
     private _activationKeyStatus(

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1264,9 +1264,14 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
             ActivationKey.CTRL,
             ActivationKey.ALT,
             ActivationKey.SUPER,
+            ActivationKey.RIGHT_BUTTON,
         ];
-        activationKeys.forEach((k) => options.append(ActivationKey[k]));
-        options.append('(None)');
+        const labelFor = (k: ActivationKey): string =>
+            k === ActivationKey.RIGHT_BUTTON
+                ? _('Right Mouse Button')
+                : ActivationKey[k];
+        activationKeys.forEach((k) => options.append(labelFor(k)));
+        options.append(_('(None)'));
         const dropdown = new Gtk.DropDown({
             model: options,
             selected: initialValue,

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -7,6 +7,7 @@ export enum ActivationKey {
     CTRL = 0,
     ALT,
     SUPER,
+    RIGHT_BUTTON,
 }
 
 export enum EdgeTilingMode {


### PR DESCRIPTION
## Intro

Hi @domferr, first off - great extension! :tada: 

Similar to @MKrabs (#443) and @percolator25 (#70) I've been using PowerToys/FancyZones on Windows and used to RMB activation of tiles. I noticed the feature requests closed, dug deeper, and found that despite Mutter stopping the drag immediately on RMB press there is a workaround - more straight-forward than what @tho-maj proposed in #509.

Tested in Vagrant against v44 and v49 and filing a PR to `main` per contribution instructions. Though, have it running as well on v50 ([my fork PR](https://github.com/egme/tilingshell/pull/1) on top of v18.0)

## Summary

Adds `RIGHT_BUTTON` as a fourth option in the activation-key dropdowns for all three Tiling Shell settings (tiling-system activation, deactivation, and span-multiple-tiles), alongside CTRL/ALT/SUPER. Users can hold RMB while dragging with LMB to control tiling, on equal footing with keyboard modifiers.

## Why this isn't a one-liner

Naïvely extending the `ActivationKey` enum and adding a button-mask switch case does **not** work. **Mutter ends the move-grab on any non-LMB press.** [`meta-window-drag.c:1883-1890`](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/compositor/meta-window-drag.c#L1883-1890) — the `CLUTTER_BUTTON_PRESS` handler unconditionally calls `end_grab_op()` during a MOVING grab. Source comment: *"the case of pressing extra mouse buttons while a grab op is ongoing"*. So pressing RMB during a window drag terminates the drag before the extension's 15 ms polling loop can observe the bit. This has been Mutter's behavior since the 2022 [simplification commit](https://gitlab.gnome.org/GNOME/mutter/-/commit/43081fc8bd6639464aa7bedb9e80e99837086899) and was equivalent under the prior `grab_button != event->button.button` logic.

## How the workaround works

`clutter_event_add_filter()` runs registered filters in [`_clutter_event_process_filters`](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/clutter/clutter/clutter-event.c#L1236) (called from [`clutter-main.c:206`](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/clutter/clutter/clutter-main.c#L206)) **before** event delivery to actors, including Mutter's grab-installed `ClutterInputOnlyActor`. A filter returning `CLUTTER_EVENT_STOP` consumes the event; `meta_window_drag_process_event` never runs.

Crucially, the seat backend mutates `seat_impl->button_state` **before** queuing the event — see [`meta-seat-impl.c:1071-1078`](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/backends/native/meta-seat-impl.c#L1071-1078). Subsequent `clutter_seat_query_state()` (the API behind `global.get_pointer()`, via [`meta-seat-impl.c:3537-3552`](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/backends/native/meta-seat-impl.c#L3537-3552)) returns `button_state | xkb_modifiers`. So the held-RMB bit (`BUTTON2_MASK`) still appears in the modifier mask read by the polling loop, even though Mutter's grab handler never saw the event.

Data flow for a chorded drag:

```
LMB-down on titlebar → Mutter starts MOVING grab
  → tilingManager._onWindowGrabBegin runs
    → if any activation key is RIGHT_BUTTON:
        install Clutter event filter on global.stage
    → 15 ms polling timer starts

RMB-down during drag
  → seat_impl button_state |= BUTTON2_MASK   (meta-seat-impl.c:1075)
  → seat_impl emits CLUTTER_BUTTON_PRESS
  → Clutter dispatcher invokes our filter first
    → returns CLUTTER_EVENT_STOP
  → event swallowed; Mutter never sees it; grab stays alive
  → next polling tick: global.get_pointer()[2] now has BUTTON2_MASK
  → existing _activationKeyStatus() trips → tiling overlay shows

LMB-up on target tile
  → Mutter CLUTTER_BUTTON_RELEASE handler (button == 1) → end_grab_op
  → tilingManager._onWindowGrabEnd runs
    → removes the Clutter event filter
  → polling timer stops
```

The filter installs only at grab-begin (and only when at least one of the three activation-key settings is `RIGHT_BUTTON`) and is removed at grab-end, so RMB outside drags continues to behave normally everywhere (context menus, etc.).

## Compatibility & safety

- Existing CTRL/ALT/SUPER selections behave identically — the new switch case and filter only execute when a user explicitly selects `RIGHT_BUTTON` somewhere.
- Filter is removed at both `_onWindowGrabEnd` and in `destroy()` — no leak across extension reload mid-drag.
- Runtime guard for `Clutter.event_add_filter` availability on the active GJS version. If missing, logs a `console.error` and degrades gracefully (RIGHT_BUTTON selection silently has no effect; no crash). The `(Clutter as any)` cast is intentional and commented — `@girs/clutter` type stubs do not always include this binding.

## Known limitations

- **Touch / tablet input:** no RMB available on touch devices. Touch users who select `RIGHT_BUTTON` will see no effect.
- **Filter scope:** while active during a drag, application context menus from RMB clicks are intentionally suppressed for the duration of the drag — the whole point is for Mutter (and apps under the cursor) to ignore RMB until LMB is released.
- **Esc during chord commits, doesn't restore:** this is pre-existing tilingshell behavior — `_onWindowGrabEnd` checks if the activation key is still held at grab-end and commits if so, regardless of how the grab ended. CTRL chord + Esc behaves the same way. Out of scope for this PR.

## Testing

Verified manually in Vagrant VMs targeting both legacy (`gnome44`) and modern (`gnome49`, closest available to GNOME 50) shells:

- [x] Defaults unchanged: CTRL activation still works for window drag + tile selection
- [x] RMB activation: LMB-drag + hold RMB → tiling overlay appears; release LMB on tile commits
- [x] No-chord drag: LMB-drag without RMB → normal window move, no overlay
- [x] Transient RMB tap during drag: overlay flashes correctly
- [x] Span via RMB: works as expected (CTRL activation + RMB span chord)
- [x] Right-click outside any drag: context menus work normally (filter is uninstalled)
- [x] No `JS WARNING` messages in `journalctl /usr/bin/gnome-shell`
- [x] No leftover RMB filter after a drag ends (subsequent drag still responds to RMB)
- [x] Build clean (`npm run build`) on both v18.0 and main branches