### PR TITLE
Fix/fractional scaling and tiling bugs

### DIFF
--- a/src/components/editor/editorDialog.ts
+++ b/src/components/editor/editorDialog.ts
@@ -42,7 +42,7 @@ export default class EditorDialog extends ModalDialog.ModalDialog {
         if (params.enableScaling) {
             const monitor = Main.layoutManager.findMonitorForActor(this);
             const scalingFactor = getMonitorScalingFactor(
-                monitor?.index || Main.layoutManager.primaryIndex,
+                monitor?.index ?? Main.layoutManager.primaryIndex,
             );
             enableScalingFactorSupport(this, scalingFactor);
         }
@@ -60,7 +60,52 @@ export default class EditorDialog extends ModalDialog.ModalDialog {
             styleClass: 'layouts-box-layout',
             xAlign: Clutter.ActorAlign.CENTER,
         });
-        this.contentLayout.add_child(this._layoutsBoxLayout);
+        // place the layouts inside a horizontal scroll view so the dialog
+        // fits the screen when there are many layouts or a low resolution
+        const scrollView = new St.ScrollView({
+            style_class: 'hfade',
+            hscrollbar_policy: St.PolicyType.AUTOMATIC,
+            vscrollbar_policy: St.PolicyType.NEVER,
+            x_expand: true,
+        });
+        // @ts-expect-error "add_actor is valid for GNOME <= 45"
+        if (scrollView.add_actor)
+            // @ts-expect-error "add_actor is valid for GNOME <= 45"
+            scrollView.add_actor(this._layoutsBoxLayout);
+        else scrollView.add_child(this._layoutsBoxLayout);
+        this.contentLayout.add_child(scrollView);
+
+        // St.ScrollView scrolls horizontally on LEFT/RIGHT scroll events only,
+        // so map mouse wheel scrolling to the horizontal axis
+        const hadjustment: St.Adjustment =
+            scrollView.hadjustment ??
+            // @ts-expect-error "get_hscroll_bar is valid for GNOME < 48"
+            scrollView.get_hscroll_bar().adjustment;
+        scrollView.connect(
+            'scroll-event',
+            (_: St.ScrollView, event: Clutter.Event) => {
+                let delta = 0;
+                switch (event.get_scroll_direction()) {
+                    case Clutter.ScrollDirection.UP:
+                    case Clutter.ScrollDirection.LEFT:
+                        delta = -1;
+                        break;
+                    case Clutter.ScrollDirection.DOWN:
+                    case Clutter.ScrollDirection.RIGHT:
+                        delta = 1;
+                        break;
+                    case Clutter.ScrollDirection.SMOOTH: {
+                        const [dx, dy] = event.get_scroll_delta();
+                        delta = dx !== 0 ? dx : dy;
+                        break;
+                    }
+                    default:
+                        return Clutter.EVENT_PROPAGATE;
+                }
+                hadjustment.adjust_for_scroll_event(delta);
+                return Clutter.EVENT_STOP;
+            },
+        );
 
         if (!params.legend) {
             this._drawLayouts({

--- a/src/components/snapassist/snapAssist.ts
+++ b/src/components/snapassist/snapAssist.ts
@@ -10,7 +10,6 @@ import SignalHandling from '../../utils/signalHandling';
 import {
     buildMarginOf,
     enableScalingFactorSupport,
-    getMonitorScalingFactor,
     getScalingFactorOf,
 } from '../../utils/ui';
 import { buildBlurEffect } from '../../utils/gnomesupport';
@@ -65,9 +64,8 @@ class SnapAssistContent extends St.BoxLayout {
     private _blur: boolean;
     private _snapAssistantThreshold: number;
     private _snapAssistantAnimationTime: number;
-    private _monitorIndex: number;
 
-    constructor(container: St.Widget, monitorIndex: number) {
+    constructor(container: St.Widget) {
         super({
             name: 'snap_assist_content',
             xAlign: Clutter.ActorAlign.CENTER,
@@ -85,9 +83,7 @@ class SnapAssistContent extends St.BoxLayout {
         this._padding = 0;
         this._blur = false;
         this._snapAssistantAnimationTime = 100;
-        this._monitorIndex = monitorIndex;
-        this._snapAssistantThreshold =
-            54 * getMonitorScalingFactor(this._monitorIndex);
+        this._snapAssistantThreshold = 54 * getScalingFactorOf(this)[1];
 
         Settings.bind(
             Settings.KEY_ENABLE_BLUR_SNAP_ASSISTANT,
@@ -140,8 +136,7 @@ class SnapAssistContent extends St.BoxLayout {
     }
 
     private set snapAssistantThreshold(value: number) {
-        this._snapAssistantThreshold =
-            value * getMonitorScalingFactor(this._monitorIndex);
+        this._snapAssistantThreshold = value * getScalingFactorOf(this)[1];
     }
 
     private set snapAssistantAnimationTime(value: number) {
@@ -402,7 +397,6 @@ export default class SnapAssist extends St.Widget {
     constructor(
         parent: Clutter.Actor,
         workArea: Mtk.Rectangle,
-        monitorIndex: number,
         scalingFactor?: number,
     ) {
         super();
@@ -411,7 +405,7 @@ export default class SnapAssist extends St.Widget {
         this.set_clip(0, 0, workArea.width, workArea.height);
         if (scalingFactor) enableScalingFactorSupport(this, scalingFactor);
 
-        this._content = new SnapAssistContent(this, monitorIndex);
+        this._content = new SnapAssistContent(this);
     }
 
     public set workArea(newWorkArea: Mtk.Rectangle) {

--- a/src/components/tilingsystem/tilingLayout.ts
+++ b/src/components/tilingsystem/tilingLayout.ts
@@ -453,7 +453,7 @@ export default class TilingLayout extends LayoutWidget<DynamicTilePreview> {
 
         const sourceCenter = {
             x: source.x + source.width / 2,
-            y: source.x + source.height / 2,
+            y: source.y + source.height / 2,
         };
 
         for (let i = 0; i < this._previews.length; i++) {

--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -149,7 +149,6 @@ export class TilingManager {
         this._snapAssist = new SnapAssist(
             Main.uiGroup,
             this._workArea,
-            this._monitor.index,
             monitorScalingFactor,
         );
     }
@@ -392,7 +391,7 @@ export class TilingManager {
                 64, // if the gaps are all 0 we choose 64 instead
                 tilingLayout.innerGaps.right,
                 tilingLayout.innerGaps.left,
-                tilingLayout.innerGaps.right,
+                tilingLayout.innerGaps.top,
                 tilingLayout.innerGaps.bottom,
             );
             destination = tilingLayout.findNearestTileDirection(
@@ -1335,8 +1334,8 @@ export class TilingManager {
         let bestTileIndex = 0;
         let bestDistance = Math.abs(
             0.5 -
-                vacantTiles[bestTileIndex].x +
-                vacantTiles[bestTileIndex].width / 2,
+                (vacantTiles[bestTileIndex].x +
+                    vacantTiles[bestTileIndex].width / 2),
         );
         for (let index = 1; index < vacantTiles.length; index++) {
             const distance = Math.abs(

--- a/src/components/window_menu/overriddenWindowMenu.ts
+++ b/src/components/window_menu/overriddenWindowMenu.ts
@@ -2,7 +2,7 @@
 import * as windowMenu from 'resource:///org/gnome/shell/ui/windowMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import { GObject, St, Clutter, Meta } from '../../gi/ext';
+import { GObject, St, Clutter, Meta, Gio } from '../../gi/ext';
 import GlobalState from '../../utils/globalState';
 import { registerGObjectClass } from '../../utils/gjs';
 import Tile from '../../components/layout/Tile';
@@ -10,6 +10,7 @@ import {
     enableScalingFactorSupport,
     getMonitorScalingFactor,
     getWindows,
+    isFractionalScalingEnabled,
 } from '../../utils/ui';
 import ExtendedWindow from '../../components/tilingsystem/extendedWindow';
 import TileUtils from '../../components/layout/TileUtils';
@@ -131,7 +132,9 @@ export default class OverriddenWindowMenu extends GObject.Object {
         });
 
         const enableScaling =
-            window.get_monitor() === Main.layoutManager.primaryIndex;
+            !isFractionalScalingEnabled(
+                new Gio.Settings({ schemaId: 'org.gnome.mutter' }),
+            ) && window.get_monitor() === Main.layoutManager.primaryIndex;
         const scalingFactor = getMonitorScalingFactor(window.get_monitor());
 
         if (vacantTiles.length > 0) {
@@ -140,8 +143,8 @@ export default class OverriddenWindowMenu extends GObject.Object {
             let bestTileIndex = 0;
             let bestDistance = Math.abs(
                 0.5 -
-                    vacantTiles[bestTileIndex].x +
-                    vacantTiles[bestTileIndex].width / 2,
+                    (vacantTiles[bestTileIndex].x +
+                        vacantTiles[bestTileIndex].width / 2),
             );
             for (let index = 1; index < vacantTiles.length; index++) {
                 const distance = Math.abs(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import {
     filterUnfocusableWindows,
     getMonitors,
     getWindows,
+    isFractionalScalingEnabled,
     squaredEuclideanDistance,
 } from './utils/ui';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
@@ -240,7 +241,7 @@ export default class TilingShellExtension extends Extension {
                 if (this._windowBorderManager)
                     this._windowBorderManager.destroy();
                 this._windowBorderManager = new WindowBorderManager(
-                    this._fractionalScalingEnabled,
+                    !this._fractionalScalingEnabled,
                 );
                 this._windowBorderManager.enable();
             },
@@ -751,15 +752,7 @@ export default class TilingShellExtension extends Extension {
     private _isFractionalScalingEnabled(
         _mutterSettings: Gio.Settings,
     ): boolean {
-        return (
-            _mutterSettings
-                .get_strv('experimental-features')
-                .find(
-                    (feat) =>
-                        feat === 'scale-monitor-framebuffer' ||
-                        feat === 'x11-randr-fractional-scaling',
-                ) !== undefined
-        );
+        return isFractionalScalingEnabled(_mutterSettings);
     }
 
     disable(): void {

--- a/src/indicator/defaultMenu.ts
+++ b/src/indicator/defaultMenu.ts
@@ -182,7 +182,7 @@ export default class DefaultMenu implements CurrentMenu {
                 this._container,
             );
             const scalingFactor = getMonitorScalingFactor(
-                monitor?.index || Main.layoutManager.primaryIndex,
+                monitor?.index ?? Main.layoutManager.primaryIndex,
             );
             enableScalingFactorSupport(this._container, scalingFactor);
         }
@@ -248,7 +248,7 @@ export default class DefaultMenu implements CurrentMenu {
                 this._container,
             );
             const scalingFactor = getMonitorScalingFactor(
-                monitor?.index || Main.layoutManager.primaryIndex,
+                monitor?.index ?? Main.layoutManager.primaryIndex,
             );
             enableScalingFactorSupport(this._container, scalingFactor);
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -64,6 +64,17 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
         Settings.initialize(this.getSettings());
         this.loadCssAndResources();
 
+        // by default the window is too small for its content, give it a
+        // larger default size, clamped to the monitor size for low resolutions
+        const monitor = Gdk.Display.get_default()
+            ?.get_monitors()
+            ?.get_item(0) as Gdk.Monitor | null;
+        const geometry = monitor?.get_geometry();
+        window.set_default_size(
+            Math.min(720, Math.round(0.9 * (geometry?.width ?? 720))),
+            Math.min(940, Math.round(0.9 * (geometry?.height ?? 940))),
+        );
+
         const prefsPage = new Adw.PreferencesPage({
             name: 'general',
             title: _('General'),

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -1,6 +1,7 @@
-import { St, Meta, Mtk, Clutter } from '../gi/ext';
+import { St, Meta, Mtk, Clutter, Gio, GLib } from '../gi/ext';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { Monitor } from 'resource:///org/gnome/shell/ui/layout.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 
 export const getMonitors = (): Monitor[] => Main.layoutManager.monitors;
 
@@ -93,6 +94,29 @@ export const buildTileGaps = (
         isBottom,
         isLeft,
     };
+};
+
+export const isFractionalScalingEnabled = (
+    mutterSettings: Gio.Settings,
+): boolean => {
+    // Since GNOME 49, fractional scaling (the logical monitor layout mode) is
+    // enabled by default on Wayland and is no longer an experimental feature
+    const GNOME_VERSION_MAJOR = Number(Config.PACKAGE_VERSION.split('.')[0]);
+    // Meta.is_wayland_compositor() was removed in newer GNOME versions
+    const isWayland = Meta.is_wayland_compositor
+        ? Meta.is_wayland_compositor()
+        : GLib.getenv('XDG_SESSION_TYPE') === 'wayland';
+    if (isWayland && GNOME_VERSION_MAJOR >= 49) return true;
+
+    return (
+        mutterSettings
+            .get_strv('experimental-features')
+            .find(
+                (feat) =>
+                    feat === 'scale-monitor-framebuffer' ||
+                    feat === 'x11-randr-fractional-scaling',
+            ) !== undefined
+    );
 };
 
 export const getMonitorScalingFactor = (monitorIndex: number) => {

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -1,6 +1,7 @@
-import { St, Meta, Mtk, Clutter } from '../gi/ext';
+import { St, Meta, Mtk, Clutter, Gio } from '../gi/ext';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { Monitor } from 'resource:///org/gnome/shell/ui/layout.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 
 export const getMonitors = (): Monitor[] => Main.layoutManager.monitors;
 
@@ -93,6 +94,25 @@ export const buildTileGaps = (
         isBottom,
         isLeft,
     };
+};
+
+export const isFractionalScalingEnabled = (
+    mutterSettings: Gio.Settings,
+): boolean => {
+    // Since GNOME 49, fractional scaling (the logical monitor layout mode) is
+    // enabled by default on Wayland and is no longer an experimental feature
+    const GNOME_VERSION_MAJOR = Number(Config.PACKAGE_VERSION.split('.')[0]);
+    if (Meta.is_wayland_compositor() && GNOME_VERSION_MAJOR >= 49) return true;
+
+    return (
+        mutterSettings
+            .get_strv('experimental-features')
+            .find(
+                (feat) =>
+                    feat === 'scale-monitor-framebuffer' ||
+                    feat === 'x11-randr-fractional-scaling',
+            ) !== undefined
+    );
 };
 
 export const getMonitorScalingFactor = (monitorIndex: number) => {


### PR DESCRIPTION
## Problem

Since GNOME 49, fractional scaling (logical monitor layout mode) is enabled by
default on Wayland and is no longer listed in mutter's `experimental-features`.
The extension therefore assumed it was disabled and applied the monitor scale
factor on top of the compositor's own scaling. At 150% scale this made the
indicator menu, snap assistant, layout editor and tile previews 1.5x too big
(the menu did not even fit the screen) and the window border too thick and
misplaced.

While debugging this, I also found a few unrelated tile geometry bugs.

## Fractional scaling fixes

- Add `isFractionalScalingEnabled()` helper that treats fractional scaling as
  enabled on GNOME 49+ Wayland sessions (with a fallback to
  `XDG_SESSION_TYPE`, since `Meta.is_wayland_compositor()` was removed in
  newer GNOME versions).
- Fix inverted `enableScaling` flag when recreating `WindowBorderManager` on
  `experimental-features` changes.
- Gate the snap assistant threshold and the overridden window menu scaling on
  actual scaling support instead of applying the monitor scale factor
  unconditionally.

## Tile geometry fixes

- `findNearestTile` used `source.x` for the **y** coordinate of the window
  center, selecting a wrong tile when moving across monitors.
- Missing parentheses in the "best tile" distance computation in auto-tiling
  and in the overridden window menu.
- Use `innerGaps.top` (instead of `.right` twice) when enlarging the search
  area for keyboard-driven tiling.
- Use `??` instead of `||` for the monitor index fallback, so monitor 0 is not
  mistaken for the primary monitor.

## UI fixes

- Wrap the editor dialog's layouts row in a horizontal `St.ScrollView` so the
  dialog fits the screen with many layouts or low resolutions (mouse wheel
  scrolls horizontally).
- Give the preferences window a proper default size (720x940, clamped to 90%
  of the monitor size) instead of opening smaller than its content.

Tested only on my own setup: GNOME Shell 50.3, Fedora, Wayland, with
fractional scaling. Other configurations (X11, older GNOME versions) were not
tested — review of the version-gated paths is appreciated.

** Generated by Fable 5. I hope the corrections are correct.