### PR TITLE
feat: disambiguate same-named monitors with relative position labels

### DIFF
--- a/src/indicator/defaultMenu.ts
+++ b/src/indicator/defaultMenu.ts
@@ -337,19 +337,17 @@ export default class DefaultMenu implements CurrentMenu {
             const metaMonitor = metaMonitors[0];
             if (!metaMonitor.get_display_name) return;
 
-            // MetaLogicalMonitor has x, y as direct properties
-            const x = (logicalMonitor as any).x ?? 0;
-            const y = (logicalMonitor as any).y ?? 0;
-            // take width and height from the shell's monitor with the
-            // same index, since MetaLogicalMonitor does not expose them
+            // MetaLogicalMonitor exposes no geometry to GJS (only
+            // get_monitors() and get_number()), so take x, y, width and
+            // height from the shell's monitor with the same index
             const shellMonitor = shellMonitors.find(
                 (m) => m.index === logicalMonitor.get_number(),
             );
             monitorsDetails.push({
                 name: metaMonitor.get_display_name(),
                 index: logicalMonitor.get_number(),
-                x,
-                y,
+                x: shellMonitor?.x ?? 0,
+                y: shellMonitor?.y ?? 0,
                 width: shellMonitor?.width,
                 height: shellMonitor?.height,
             });

--- a/src/indicator/defaultMenu.ts
+++ b/src/indicator/defaultMenu.ts
@@ -20,6 +20,7 @@ import Layout from '../components/layout/Layout';
 import { _ } from '../translations';
 import { widgetOrientation } from '../utils/gnomesupport';
 import { createButton, createIconButton } from './utils';
+import { disambiguateMonitorNames, MonitorDetails } from './monitorNames';
 
 const debug = logger('DefaultMenu');
 
@@ -105,14 +106,7 @@ class LayoutsRow extends St.BoxLayout {
 
     public updateMonitorName(
         showMonitorName: boolean,
-        monitorsDetails: {
-            name: string;
-            index?: number;
-            x?: number;
-            y?: number;
-            height?: number;
-            width?: number;
-        }[],
+        monitorsDetails: MonitorDetails[],
     ) {
         if (!showMonitorName) this._label.hide();
         else this._label.show();
@@ -278,16 +272,13 @@ export default class DefaultMenu implements CurrentMenu {
         }
 
         // GNOME 49+ has Meta.Monitor with get_display_name()
-        const monitorsDetails: {
-            name: string;
-            index: number;
-            x: number;
-            y: number;
-        }[] | undefined = this._get_display_name();
+        const monitorsDetails: MonitorDetails[] | undefined =
+            this._get_display_name();
 
         if (monitorsDetails) {
+            const disambiguated = disambiguateMonitorNames(monitorsDetails);
             this._layoutsRows.forEach((lr) =>
-                lr.updateMonitorName(true, monitorsDetails),
+                lr.updateMonitorName(true, disambiguated),
             );
             return;
         }
@@ -313,8 +304,11 @@ export default class DefaultMenu implements CurrentMenu {
                     if (pr.get_successful()) {
                         debug(stdout);
                         const parsedMonitorsDetails = JSON.parse(stdout);
+                        const disambiguated = disambiguateMonitorNames(
+                            parsedMonitorsDetails,
+                        );
                         this._layoutsRows.forEach((lr) =>
-                            lr.updateMonitorName(true, parsedMonitorsDetails),
+                            lr.updateMonitorName(true, disambiguated),
                         );
                     } else {
                         debug('error:', stderr);
@@ -327,19 +321,15 @@ export default class DefaultMenu implements CurrentMenu {
     }
 
     // Use GNOME 49+'s Meta.Monitor with get_display_name()
-    private _get_display_name() {
+    private _get_display_name(): MonitorDetails[] | undefined {
         const monitorManager = global.backend.get_monitor_manager();
         if (!monitorManager.get_logical_monitors) return undefined;
 
         const logicalMonitors = monitorManager.get_logical_monitors();
         if (!logicalMonitors || logicalMonitors.length <= 0) return undefined;
 
-        const monitorsDetails: {
-            name: string;
-            index: number;
-            x: number;
-            y: number;
-        }[] = [];
+        const shellMonitors = getMonitors();
+        const monitorsDetails: MonitorDetails[] = [];
         logicalMonitors.forEach(logicalMonitor => {
             const metaMonitors = logicalMonitor.get_monitors();
             if (metaMonitors.length <= 0) return;
@@ -350,11 +340,18 @@ export default class DefaultMenu implements CurrentMenu {
             // MetaLogicalMonitor has x, y as direct properties
             const x = (logicalMonitor as any).x ?? 0;
             const y = (logicalMonitor as any).y ?? 0;
+            // take width and height from the shell's monitor with the
+            // same index, since MetaLogicalMonitor does not expose them
+            const shellMonitor = shellMonitors.find(
+                (m) => m.index === logicalMonitor.get_number(),
+            );
             monitorsDetails.push({
                 name: metaMonitor.get_display_name(),
                 index: logicalMonitor.get_number(),
                 x,
                 y,
+                width: shellMonitor?.width,
+                height: shellMonitor?.height,
             });
         });
 

--- a/src/indicator/monitorNames.ts
+++ b/src/indicator/monitorNames.ts
@@ -1,0 +1,154 @@
+import { _ } from '../translations';
+
+export interface MonitorDetails {
+    name: string;
+    index?: number;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+}
+
+// clustering tolerance (in pixels) used when no monitor size is available
+const FALLBACK_CLUSTER_TOLERANCE = 100;
+
+// Half of the smallest known monitor dimension: two monitors whose centers
+// are closer than this on an axis are considered aligned on that axis
+const clusterTolerance = (group: MonitorDetails[]): number => {
+    const sizes = group
+        .flatMap(m => [m.width ?? 0, m.height ?? 0])
+        .filter(size => size > 0);
+    return sizes.length > 0
+        ? Math.min(...sizes) / 2
+        : FALLBACK_CLUSTER_TOLERANCE;
+};
+
+// Group values into clusters: a value starts a new cluster when it is
+// farther than the tolerance from the start of the current cluster.
+// Returns the cluster rank of each value (0 = leftmost/topmost)
+const clusterRanks = (
+    values: number[],
+    tolerance: number
+): Map<number, number> => {
+    const sorted = Array.from(new Set(values)).sort((a, b) => a - b);
+    const ranks = new Map<number, number>();
+    let rank = 0;
+    let clusterStart = sorted.length > 0 ? sorted[0] : 0;
+    sorted.forEach(value => {
+        if (value - clusterStart > tolerance) {
+            rank++;
+            clusterStart = value;
+        }
+        ranks.set(value, rank);
+    });
+    return ranks;
+};
+
+const horizontalKey = (rank: number, count: number): string => {
+    if (count <= 1) return '';
+    if (rank === 0) return 'left';
+    if (rank === count - 1) return 'right';
+    return 'middle';
+};
+
+const verticalKey = (rank: number, count: number): string => {
+    if (count <= 1) return '';
+    if (rank === 0) return 'top';
+    if (rank === count - 1) return 'bottom';
+    return 'middle';
+};
+
+// Whole phrases are translated (instead of composing translated words)
+// since word order differs between languages
+const translatePositionKey = (key: string): string => {
+    switch (key) {
+        case 'left':
+            return _('left');
+        case 'right':
+            return _('right');
+        case 'top':
+            return _('top');
+        case 'bottom':
+            return _('bottom');
+        case 'middle':
+            return _('middle');
+        case 'top left':
+            return _('top left');
+        case 'top middle':
+            return _('top middle');
+        case 'top right':
+            return _('top right');
+        case 'middle left':
+            return _('middle left');
+        case 'middle right':
+            return _('middle right');
+        case 'bottom left':
+            return _('bottom left');
+        case 'bottom middle':
+            return _('bottom middle');
+        case 'bottom right':
+            return _('bottom right');
+        default:
+            return key;
+    }
+};
+
+// Compute a position label (e.g. "left", "top right") for each monitor of
+// a group sharing the same name. Labels are unique and non-empty within
+// the group: duplicated labels (e.g. mirrored monitors, or four monitors
+// in a row where two are "middle") are numbered
+const computePositionLabels = (group: MonitorDetails[]): string[] => {
+    const centersX = group.map(m => (m.x ?? 0) + (m.width ?? 0) / 2);
+    const centersY = group.map(m => (m.y ?? 0) + (m.height ?? 0) / 2);
+    const tolerance = clusterTolerance(group);
+    const columnRanks = clusterRanks(centersX, tolerance);
+    const rowRanks = clusterRanks(centersY, tolerance);
+    const columns = Math.max(...Array.from(columnRanks.values())) + 1;
+    const rows = Math.max(...Array.from(rowRanks.values())) + 1;
+
+    const keys = group.map((m, i) => {
+        const h = horizontalKey(columnRanks.get(centersX[i])!, columns);
+        const v = verticalKey(rowRanks.get(centersY[i])!, rows);
+        if (v.length > 0 && h.length > 0)
+            return v === 'middle' && h === 'middle' ? 'middle' : `${v} ${h}`;
+        return v.length > 0 ? v : h;
+    });
+
+    const occurrences = new Map<string, number>();
+    keys.forEach(key => occurrences.set(key, (occurrences.get(key) ?? 0) + 1));
+    const counters = new Map<string, number>();
+    return keys.map(key => {
+        const label = translatePositionKey(key);
+        if ((occurrences.get(key) ?? 0) <= 1) return label;
+        const n = (counters.get(key) ?? 0) + 1;
+        counters.set(key, n);
+        return label.length > 0 ? `${label} ${n}` : `${n}`;
+    });
+};
+
+// Append the relative position (e.g. "(left)", "(top right)") to the name
+// of the monitors sharing their name with another monitor, leaving unique
+// names untouched. Does not mutate the given monitors
+export const disambiguateMonitorNames = (
+    monitors: MonitorDetails[]
+): MonitorDetails[] => {
+    const groups = new Map<string, MonitorDetails[]>();
+    monitors.forEach(m => {
+        const group = groups.get(m.name);
+        if (group) group.push(m);
+        else groups.set(m.name, [m]);
+    });
+
+    const renamed = new Map<MonitorDetails, string>();
+    groups.forEach((group, name) => {
+        if (group.length <= 1) return;
+        computePositionLabels(group).forEach((label, i) =>
+            renamed.set(group[i], `${name} (${label})`)
+        );
+    });
+
+    return monitors.map(m => {
+        const newName = renamed.get(m);
+        return newName === undefined ? { ...m } : { ...m, name: newName };
+    });
+};


### PR DESCRIPTION
## Summary

Fixes #81.

When two or more monitors are the same model, the indicator menu shows identical names for all of them, so there is no way to tell which layout row belongs to which monitor. This PR appends a relative position label to the name of any monitor that shares its name with another one, e.g.:

- `DELL U2723QE (left)` / `DELL U2723QE (right)`
- `LG HDR 4K (top)` / `LG HDR 4K (bottom)`
- `ASUS PB278 (top left)` / `ASUS PB278 (top right)` / `ASUS PB278 (bottom)`

Monitors with unique names are left untouched, so nothing changes for setups that aren't affected by the problem.

## Why position labels instead of number suffixes

The discussion in #81 originally converged on appending the monitor's number (e.g. `LG Electronics 34" 1`, `LG Electronics 34" 2`). This PR instead implements the relative position labels later suggested by @rloutrel in that thread, for the reason @GuillaumeAmat reported: monitor numbers get reassigned interchangeably every time a monitor is (un)plugged, so a number suffix doesn't reliably tell the user which physical screen a row refers to, while "left"/"right" does. Numbers are still used as a tie-breaker when positions can't disambiguate (e.g. mirrored displays get `middle 1` / `middle 2`).

## How it works

- New `src/indicator/monitorNames.ts` exposes `disambiguateMonitorNames()`, which groups monitors by name and computes a position label only for groups with duplicates.
- Positions are derived by clustering monitor center points into columns and rows. The clustering tolerance is half of the smallest monitor dimension in the group (with a fallback when geometry is unavailable), so slightly misaligned monitors still land in the same row/column.
- Labels are picked from the cluster ranks: `left`/`middle`/`right` horizontally and `top`/`middle`/`bottom` vertically, combined when the group spans both axes (e.g. `top right`).
- If two monitors in a group would still get the same label (mirrored displays, or 4-in-a-row where two are `middle`), the labels are numbered (`middle 1`, `middle 2`) so every entry stays unambiguous.
- Whole phrases are passed through `_()` rather than composing translated words, since word order differs between languages.
- Both name sources go through the same disambiguation: the GNOME 49+ `Meta.Monitor.get_display_name()` path and the `gjs` subprocess fallback used on older shells.

Since `MetaLogicalMonitor` exposes no geometry properties to GJS (only `get_monitors()` and `get_number()`), the GNOME 49+ path now reads x/y/width/height from the shell's monitors matched by monitor index instead of the previous `(logicalMonitor as any).x` access, which silently yielded `0` for every monitor. Related: #142 describes row-to-monitor confusion of a similar nature, though on an older code path — this PR does not claim to fix it.

## Test plan

- [x] `npm run lint` passes and `npm run build` succeeds
- [x] Also verified against the `v18.0` branch: no conflicts, the two files touched here lint clean, and the build succeeds — happy to retarget there if you prefer
- [x] Tested locally on GNOME 50 (Fedora) with same-model monitors: each menu entry shows the monitor name with its position label appended
- [ ] Test on GNOME shell <= 44 (subprocess fallback path — logic is shared, but I couldn't exercise it locally; happy to get help here per CONTRIBUTING.md)
- [ ] Test vertical and 2x2 arrangements on real hardware
