### PR TITLE
fix: don't tile/move the desktop-icons window on Super+Arrow

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -508,6 +508,7 @@ export default class TilingShellExtension extends Extension {
         if (
             !focus_window ||
             !focus_window.has_focus() ||
+            focus_window.windowType !== Meta.WindowType.NORMAL ||
             (focus_window.get_wm_class() &&
                 focus_window.get_wm_class() === 'gjs') ||
             focus_window.is_fullscreen()


### PR DESCRIPTION
## Summary
Fixes #183 — desktop icons appear to "float"/shift when pressing Super+Left/Right/Up/Down while no application window is focused (e.g. right after clicking empty desktop space).

## Why this happens
`_onKeyboardMoveWin` in `extension.ts` is the handler for both the `move-window` and `span-window` signals — i.e. it's what runs on every Super+Arrow press. Its guard bails out when there's no focused window, when the focused window has lost focus, when its `wm_class` is `gjs`, or when it's fullscreen:

```ts
if (
    !focus_window ||
    !focus_window.has_focus() ||
    (focus_window.get_wm_class() &&
        focus_window.get_wm_class() === 'gjs') ||
    focus_window.is_fullscreen()
)
    return;
```

But `display.get_focus_window()` doesn't only return normal application windows. When you click on empty desktop space, GNOME can hand keyboard focus to the desktop-icons window (Nautilus desktop / Desktop Icons NG). That's a real `Meta.Window`, just one with `windowType === Meta.WindowType.DESKTOP` instead of `NORMAL`. None of the existing guard conditions filter it out, so `_onKeyboardMoveWin` proceeds to tile/resize that window through `monitorTilingManager.onKeyboardMoveWindow(...)`. Resizing the desktop-icons window's frame is exactly what makes the icons appear to shift/float — Tiling Shell ends up unintentionally treating the desktop background as a tileable window.

Notably, `_onKeyboardUntileWindow` already guards against this same case with a `focus_window.windowType !== Meta.WindowType.NORMAL` check — it was just missing from `_onKeyboardMoveWin`.

## Fix
Add the same `windowType !== Meta.WindowType.NORMAL` guard (already used elsewhere in this file) to `_onKeyboardMoveWin`, so Super+Arrow is a no-op whenever the "focused window" isn't a real application window.

## Test plan
- [x] `npm run build` succeeds
- [x] Built extension installed locally on GNOME Shell 46 (Ubuntu 24.04), Tiling Shell v17.3
- [x] Verified after full logout/login: click empty desktop space, hold Super+Arrow — desktop icons no longer move
