### PR TITLE
fix: correct distance formula when picking the best vacant tile

### DIFF
--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -1333,12 +1333,8 @@ export class TilingManager {
         vacantTiles.sort((a, b) => a.x - b.x);
 
         let bestTileIndex = 0;
-        let bestDistance = Math.abs(
-            0.5 -
-                vacantTiles[bestTileIndex].x +
-                vacantTiles[bestTileIndex].width / 2,
-        );
-        for (let index = 1; index < vacantTiles.length; index++) {
+        let bestDistance = Number.MAX_VALUE;
+        for (let index = 0; index < vacantTiles.length; index++) {
             const distance = Math.abs(
                 0.5 - (vacantTiles[index].x + vacantTiles[index].width / 2),
             );

--- a/src/components/window_menu/overriddenWindowMenu.ts
+++ b/src/components/window_menu/overriddenWindowMenu.ts
@@ -138,12 +138,8 @@ export default class OverriddenWindowMenu extends GObject.Object {
             vacantTiles.sort((a, b) => a.x - b.x);
 
             let bestTileIndex = 0;
-            let bestDistance = Math.abs(
-                0.5 -
-                    vacantTiles[bestTileIndex].x +
-                    vacantTiles[bestTileIndex].width / 2,
-            );
-            for (let index = 1; index < vacantTiles.length; index++) {
+            let bestDistance = Number.MAX_VALUE;
+            for (let index = 0; index < vacantTiles.length; index++) {
                 const distance = Math.abs(
                     0.5 - (vacantTiles[index].x + vacantTiles[index].width / 2),
                 );


### PR DESCRIPTION
### Problem

When auto-tiling picks the vacant tile "nearest the centre of the screen", the loop is seeded with a differently-parenthesised expression than the one it uses in the body:

```js
// seed
Math.abs(0.5 - vacantTiles[0].x + vacantTiles[0].width / 2)
// body
Math.abs(0.5 - (vacantTiles[index].x + vacantTiles[index].width / 2))
```

The seed *adds* half the tile's width instead of subtracting it, so the first tile (leftmost, after the `sort((a, b) => a.x - b.x)` on the preceding line) gets an inflated score and loses comparisons it should win.

This is what #421 describes in its opening paragraphs:

> I use either 50/50 or 70/30 or something like that. […] I open one window — it's placed on the right side, **not sure why it detects the right side as best location not the left side**

### Effect

Running both versions of the selection code over a few layouts:

```
BUG  70/30 two-column
       tiles:  x=0 w=0.7 (centre 0.350)  |  x=0.7 w=0.3 (centre 0.850)
       before: tile 1 -> x=0.7 w=0.3    dist 0.350
       after:  tile 0 -> x=0 w=0.7      dist 0.150
BUG  67/33 two-column
       before: tile 1 -> x=0.67 w=0.33  dist 0.335
       after:  tile 0 -> x=0 w=0.67     dist 0.165
tie  50/50 two-column
       before: tile 1 -> x=0.5 w=0.5    dist 0.250
       after:  tile 0 -> x=0 w=0.5      dist 0.250
ok   three-column 25/50/25    (unchanged — the centre tile wins either way)
ok   single fullscreen tile   (unchanged)
ok   33/67 two-column         (unchanged — the correct answer is the right tile here)
```

Asymmetric two-column layouts are the clear failure: the window lands in the *narrow* tile. Symmetric layouts are a tie, and the fix resolves ties to the leftmost tile — which is what the original `bestTileIndex = 0` seed with a strict `>` comparison was already trying to do.

Layouts where the leftmost tile isn't the best answer anyway (3-column, 33/67, single tile) are unaffected.

### Fix

Seed with `Number.MAX_VALUE` and start the loop at `0`, so the distance formula exists in exactly one place and can't drift again.

The same block is copy-pasted into the window menu's **"Move to best tile"** entry, so that entry pointed at the wrong tile too. Both are fixed. 4 lines added, 12 removed.

### Testing

Verified live on GNOME Shell 50.3 (Fedora 44, Wayland), single monitor, work area `1920x1048`, auto-tiling on, a 67/33 two-column layout selected, gaps 0. Measurement is the column count of a terminal opened as the first window on an empty workspace — the two tiles are ~1286px and ~634px, so the count identifies the tile unambiguously.

| build | first window |
|---|---|
| v17.3 as released | **64 columns** × 48 lines — the narrow right tile |
| with this patch | **136 columns** × 48 lines — the wide left tile |

136/64 = 2.13 against the layout's 0.67/0.33 = 2.03. Same session, same layout, same measurement.

With a temporary probe in `_findEmptyTile` the patched build reports:

```
vacant=2 chose index=0 x=0 w=0.67 all=0:0.67,0.67:0.33
```

Worth noting for anyone testing this themselves: GNOME caches extension modules, so `disable`/`enable` keeps running the old code. My first three attempts silently measured the unpatched build. A full logout is needed.

Also:
- `npm run lint` — clean.
- `npm run build` — clean, both the main bundle (GNOME 45–50) and `dist_legacy` (GNOME 42–44).
- No new dependencies, no API surface touched.

Happy to adjust the tie-breaking direction if leftmost-first isn't what you'd prefer.

<sub>Two unrelated things I hit while setting up, mentioned only in case they're useful — no changes made for either: `npm install` fails on a clean checkout of `main` with `ERESOLVE` (`esbuild-sass-plugin@3.7.0` now wants `esbuild >=0.27.3`, root pins `^0.25.10`; `--legacy-peer-deps` works around it), and `npm run prettier:check` reports 51 pre-existing files, since the committed source uses `trailingComma: "all"` while `.prettierrc` sets `"es5"`. I deliberately didn't run `prettier --write`, to keep this diff to the two files.</sub>
